### PR TITLE
【Feature】トップページとヘッダーの作成

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,4 @@
+class StaticPagesController < ApplicationController
+  def top
+  end
+end

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -1,0 +1,2 @@
+module StaticPagesHelper
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,9 +18,22 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body>
-    <main class="container mx-auto mt-28 px-5 flex">
-      <%= yield %>
-    </main>
+  <body class="bg-base-100 min-h-screen font-mplus">
+    <!-- ドロワー全体を囲む -->
+    <div class="drawer">
+      <!-- チェックボックス（非表示） -->
+      <input id="drawer-menu" type="checkbox" class="drawer-toggle" />
+      <!-- メインコンテンツエリア -->
+      <div class="drawer-content">
+        <!-- ヘッダーの出し分け -->
+        <%= render 'shared/before_login_header' %>
+        <!-- 各ページの内容 -->
+        <main class="container mx-auto px-4 py-8">
+          <%= yield %>
+        </main>
+      </div>
+      <!-- ドロワーメニューの出し分け -->
+      <%= render 'shared/before_login_drawer_menu' %>
+    </div>
   </body>
 </html>

--- a/app/views/shared/_before_login_drawer_menu.html.erb
+++ b/app/views/shared/_before_login_drawer_menu.html.erb
@@ -1,0 +1,6 @@
+<div class="drawer-side">
+  <label for="drawer-menu" class="drawer-overlay"></label>
+  <ul class="menu p-4 w-80 bg-base-100">
+    <li><%= link_to '利用規約', "#" %></li>
+    <li><%= link_to 'プライバシーポリシー', "#" %></li>
+  </ul>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,0 +1,15 @@
+<header class="navbar bg-primary text-primary-content px-4">
+  <!-- Hamburger -->
+  <label for="drawer-menu" class="btn btn-ghost btn-sm drawer-button">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+        stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+      <path stroke-linecap="round" stroke-linejoin="round"
+        d="M4.5 6.75h15M4.5 12h15m-15 5.25h15" />
+    </svg>
+  </label>
+
+  <!-- Center Title -->
+  <div class="mx-auto text-center">
+    <span class="text-lg font-bold tracking-wider">OKAN</span>
+  </div>
+</header>

--- a/app/views/shared/_drawer_menu.html.erb
+++ b/app/views/shared/_drawer_menu.html.erb
@@ -1,0 +1,7 @@
+<div class="drawer-side">
+  <label for="drawer-menu" class="drawer-overlay"></label>
+    <ul class="menu p-4 w-80 bg-base-100">
+      <li><%= link_to '登録薬一覧', "#" %></li>
+      <li><%= link_to '残薬一覧', "#" %></li>
+    </ul>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,15 @@
+<header class="navbar bg-primary text-primary-content px-4">
+  <!-- Hamburger -->
+  <label for="drawer-menu" class="btn btn-ghost btn-sm drawer-button">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+        stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+      <path stroke-linecap="round" stroke-linejoin="round"
+        d="M4.5 6.75h15M4.5 12h15m-15 5.25h15" />
+    </svg>
+  </label>
+
+  <!-- Center Title -->
+  <div class="mx-auto text-center">
+    <span class="text-lg font-bold tracking-wider">OKAN</span>
+  </div>
+</header>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,0 +1,14 @@
+<div class="drawer">
+  <input id="drawer-menu" type="checkbox" class="drawer-toggle" />
+  <div class="drawer-content">
+
+    <!-- Body -->
+    <main class="flex flex-col items-center justify-center mt-40 px-6 space-y-5">
+      <%= link_to "新規登録", "#",
+          class: "btn btn-primary w-full max-w-xs" %>
+      <%= link_to "ログイン","#",
+          class: "btn bg-white text-[#E56A54] border border-[#E56A54] hover:bg-[#FFE4DF] w-full max-w-xs" %>
+      <%= link_to "ログアウト","#", data: { turbo_method: :delete } %>
+    </main>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  root "posts#index"
+  root "static_pages#top"
 end

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class StaticPagesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 概要
トップページを作成しました。
ヘッダーをログイン前とログイン後に分けて部分テンプレートに切り出しました。

### 作業内容
**トップページ**

1.  以下のコマンドでstatic_pagesのcontrollerとviewを作成

```
docker compose exec web bin/rails g controller static_pages
```
2. ルーティング、controller、viewを記述


**ヘッダー**
ログイン前
- _before_login_header.html.erbにハンバーガーメニューとOKANのロゴを表示する記述
- _before_login_drawer_menu.html.erbにハンバーガーメニューを開いたときの内容を記述（利用規約、プライバシーポリシー）
ログイン後
- _header.html.erbにハンバーガーメニューとOKANのロゴを表示する記述
- _drawer.menu.html.erbにハンバーガーメニューを開いたときの内容を記述（登録薬一覧、残薬一覧）
- applocation.html.erbにログイン前のヘッダーの表示を記述

### 機能追加理由
localhost:3000にアクセスした時ルート表示が必要なためのトップページを作成しました。
複数箇所で効率よく記述できるようにするため、ヘッダーを部分テンプレート化しました。

### 備考
ログイン機能は未実装のためapplocation.html.erbに条件分岐書いていません。ひとまずログイン前のヘッダーを呼び出す記述をしています。
利用規約とプライバシーポリシーはMVPに含めないためリンク先には遷移しません。