### PR TITLE
【Feature】UserMedicinesテーブルにis_regularカラムを追加

### DIFF
--- a/app/controllers/registered_medicines_controller.rb
+++ b/app/controllers/registered_medicines_controller.rb
@@ -26,6 +26,9 @@ class RegisteredMedicinesController < ApplicationController
 
     # 処方量を在庫として設定(手元に在庫がない初回登録時用)
     @user_medicine.current_stock = @user_medicine.prescribed_amount
+
+    # MVPでは全てis_regular=trueで登録
+    @medicine.is_regular = true
       if @user_medicine.save
         redirect_to registered_medicines_path, notice: "薬を登録しました"
       else

--- a/app/controllers/registered_medicines_controller.rb
+++ b/app/controllers/registered_medicines_controller.rb
@@ -27,8 +27,6 @@ class RegisteredMedicinesController < ApplicationController
     # 処方量を在庫として設定(手元に在庫がない初回登録時用)
     @user_medicine.current_stock = @user_medicine.prescribed_amount
 
-    # MVPでは全てis_regular=trueで登録
-    @medicine.is_regular = true
       if @user_medicine.save
         redirect_to registered_medicines_path, notice: "薬を登録しました"
       else

--- a/app/models/user_medicine.rb
+++ b/app/models/user_medicine.rb
@@ -1,3 +1,9 @@
 class UserMedicine < ApplicationRecord
   belongs_to :user
+
+  # いつもの薬リストに表示する薬を取得
+  scope :regular_medicines, -> { where(is_regular: true) }
+
+  # 単発の薬を取得(本リリースで使用予定)
+  scope :temporary_medicines, -> { where(is_regular: false) }
 end

--- a/db/migrate/20251209103042_add_is_regular_to_user_medicines.rb
+++ b/db/migrate/20251209103042_add_is_regular_to_user_medicines.rb
@@ -1,0 +1,5 @@
+class AddIsRegularToUserMedicines < ActiveRecord::Migration[7.2]
+  def change
+    add_column :user_medicines, :is_regular, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_04_231741) do
+ActiveRecord::Schema[7.2].define(version: 2025_12_09_103042) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,6 +23,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_04_231741) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_regular", default: true
     t.index ["user_id"], name: "index_user_medicines_on_user_id"
   end
 


### PR DESCRIPTION
### 概要

[#16]
本リリースで実装予定のいつもの薬リストに登録用にUserMedicinesテーブルにis_regularカラムを追加を追加しました。


### 作業内容

- ` docker compose exec web bin/rails generate migration AddIsRegularToUserMedicines is_regular:boolean `コマンドでマイグレーションファイルを作成して ` default = true `を追記
- docker compose exec web rails db:migrateを実行
- modelにいつもの薬リストに入れる薬のscopeを記述

### 機能追加理由

本リリースで登録薬を作成した場合にいつもの薬リストを実装するため。
### 備考

本リリースで機能を追加する際に、既存データに影響を与えずに実装するためにこの段階で追加しました。