### PR TITLE
【Feature】いつもの薬リストからの処方薬登録を実装

### DIFF
--- a/app/controllers/leftover_medicines_controller.rb
+++ b/app/controllers/leftover_medicines_controller.rb
@@ -2,4 +2,21 @@ class LeftoverMedicinesController < ApplicationController
   def index
     @leftover_medicines = current_user.user_medicines.where("current_stock > 0").order(date_of_prescription: :desc)
   end
+
+  def new
+    @user_medicine = current_user.user_medicines.find(params[:user_medicine_id])
+  end
+
+  def create
+    @user_medicine = current_user.user_medicines.find(params[:user_medicine_id])
+    # 処方量をcurrent_stockに加算
+    prescribed_amount = params[:prescribed_amount].to_i
+    @user_medicine.current_stock += prescribed_amount
+    @user_medicine.date_of_prescription = params[:date_of_prescription]
+    if @user_medicine.save
+      redirect_to leftover_medicines_path, notice: "処方薬を追加しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
 end

--- a/app/views/leftover_medicines/new.html.erb
+++ b/app/views/leftover_medicines/new.html.erb
@@ -1,0 +1,44 @@
+<div class="container mx-auto px-4 py-8">   
+  <h1 class="font-bold text-4xl flex justify-center">処方薬を追加</h1>
+  <%= form_with url: leftover_medicines_path, method: :post, class: "contents" do |form| %>
+    <%= hidden_field_tag :user_medicine_id, @user_medicine.id %>
+
+    <div class="my-5">
+      <%= label_tag :medicine_name, "薬名", class: "block font-medium text-gray-700" %>
+      <p class="mt-2 text-gray-900 text-lg">
+        <%= @user_medicine.medicine_name %>
+      </p>
+    </div>
+
+    <div class="my-5">
+      <%= label_tag :dosage_per_time, "一回の服薬量", class: "block font-medium text-gray-700" %>
+      <div class="flex items-center gap-2 mt-2">
+        <p class="text-gray-900 text-lg">
+          <%= @user_medicine.dosage_per_time %>
+        </p>
+        <span class="text-gray-700">錠</span>
+      </div>
+    </div>
+
+    <div class="my-5">
+      <%= label_tag :prescribed_amount, "処方量", class: "block font-medium text-gray-700" %>
+      <div class="flex items-center gap-4 mt-2">
+        <%= number_field_tag :prescribed_amount, nil, 
+            class: "shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 w-24",
+            required: true %>
+        <span class="text-gray-700">錠</span>
+      </div>
+    </div>
+
+    <div class="my-5">
+      <%= label_tag :date_of_prescription, "処方日", class: "block font-medium text-gray-700" %>
+      <%= date_field_tag :date_of_prescription, Date.today, 
+          class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full",
+          required: true %>
+    </div>
+
+    <div class="flex gap-4 mt-8">
+      <%= submit_tag "この内容で追加", class: "btn btn-primary flex-1" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/registered_medicines/index.html.erb
+++ b/app/views/registered_medicines/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <h1 class="font-bold text-4xl flex justify-center">登録薬一覧</h1>
+  <h1 class="font-bold text-4xl flex justify-center">いつもの薬リスト</h1>
 
   <% if @user_medicines.any? %>
     <table class="table">
@@ -16,7 +16,7 @@
             <td><%= medicine.medicine_name %></td>
             <td><%= medicine.dosage_per_time %></td>
             <td>
-              <%= link_to "選択", registered_medicine_path(medicine), class: "btn btn-sm btn-primary" %>
+              <%= link_to "選択", new_leftover_medicine_path(user_medicine_id: medicine.id), class: "btn btn-sm btn-primary" %>
             </td>
           </tr>
         <% end %>


### PR DESCRIPTION
### 概要

[#18]
登録薬一覧画面(いつもの薬リスト)から選択ボタンを押して、選択した薬と同じ薬を処方された場合に処方量と処方日を入力するだけで手元の在庫数を加算できるようにしました。
issueを作った時は登録薬詳細画面と編集画面を同じ画面に表示して、registered_medicinesコントローラーのeditアクションを実装する予定でしたが、leftover_medicinesのnewとcreateアクションとして実装することに変更しました。登録薬の詳細と変更の機能については別issueを立てて実装します。

### 作業内容

- leftover_medicines.controllerのnewとcreateアクションを記述
- leftover_medicines/new.html.erbに登録済みの薬名と1回あたりの服用量を表示し、処方量と処方日を入
- 入力するフォームを設置
- registered_medicines/index.html.erbのタイトルを「いつもの薬リスト」に変更
- いつもの薬リストページの選択ボタンの遷移先を leftover_medicinesのnewアクションに変更

### 機能追加理由

薬名と1回の服薬量があらかじめ入った状態から処方薬を登録できることで、入力の手間を減らすためです。

### 備考

issueを作った時は登録薬詳細画面と編集画面を同じ画面に表示して、registered_medicinesコントローラーのeditアクションを実装する予定でしたが、leftover_medicinesのnewとcreateアクションとして実装することに変更しました。登録薬の詳細と変更の機能については別issueを立てて実装します。
