### PR TITLE
【Feature】登録薬詳細編集画面の実装

### DIFF
--- a/app/controllers/registered_medicines_controller.rb
+++ b/app/controllers/registered_medicines_controller.rb
@@ -2,8 +2,13 @@ class RegisteredMedicinesController < ApplicationController
   before_action :set_user_medicine, only: %i[ show edit update destroy ]
   before_action :set_user_medicine, only: %i[show edit update destroy]
 
-  # GET /user_medicines or /user_medicines.json
+  # 登録薬管理用一覧（編集・削除）
   def index
+    @user_medicines = current_user.user_medicines.page(params[:page]).per(8)
+  end
+
+  # 処方箋追加用一覧（選択）
+  def select
     @user_medicines = current_user.user_medicines.page(params[:page]).per(8)
   end
 

--- a/app/views/leftover_medicines/index.html.erb
+++ b/app/views/leftover_medicines/index.html.erb
@@ -32,6 +32,6 @@
   
   <!-- 登録薬管理へのリンク -->
   <div class="actions text-center">
-    <%= link_to "薬の追加", registered_medicines_path, class: "btn btn-primary" %>
+    <%= link_to "薬の追加", select_registered_medicines_path, class: "btn btn-primary" %>
   </div>
 </div>

--- a/app/views/registered_medicines/_form.html.erb
+++ b/app/views/registered_medicines/_form.html.erb
@@ -42,7 +42,6 @@
     <%= form.date_field :date_of_prescription, class: ["block shadow-sm rounded-md border px-3 py-2 mt-2 w-full", {"border-gray-400 focus:outline-blue-600": user_medicine.errors[:date_of_prescription].none?, "border-red-400 focus:outline-red-600": user_medicine.errors[:date_of_prescription].any?}] %>
   </div>
 
-  <div class="inline">
-    <%= form.submit "この内容で追加", class: "btn btn-primary w-full" %>
-  </div>
+  <%= yield form %>
+
 <% end %>

--- a/app/views/registered_medicines/edit.html.erb
+++ b/app/views/registered_medicines/edit.html.erb
@@ -1,10 +1,12 @@
-<% content_for :title, "Editing user medicine" %>
+<div class="container mx-auto px-4 py-8">
+   <h1 class="font-bold text-4xl flex justify-center mb-4">登録薬編集</h1>
 
-<div class="md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">Editing user medicine</h1>
+   <%= render "form", user_medicine: @user_medicine do |form| %>
+     <div class="inline">
+       <%= form.submit "変更を保存", class: "btn btn-primary w-full" %>
+     </div>
+   <% end %>
 
-  <%= render "form", user_medicine: @user_medicine %>
-
-  <%= link_to "Show this user medicine", registered_medicine_path(@user_medicine), class: "w-full sm:w-auto text-center mt-2 sm:mt-0 sm:ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-  <%= link_to "Back to user medicines", registered_medicines_path, class: "w-full sm:w-auto text-center mt-2 sm:mt-0 sm:ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-</div>
+   <div class="flex justify-center mt-4">
+     <%= link_to "登録薬一覧", registered_medicines_path, class: "btn bg-white text-[#E56A54] border border-[#E56A54] hover:bg-[#FFE4DF] max-w-xs" %>
+   </div>

--- a/app/views/registered_medicines/index.html.erb
+++ b/app/views/registered_medicines/index.html.erb
@@ -1,6 +1,5 @@
 <div class="container mx-auto px-4 py-8">
-  <h1 class="font-bold text-4xl flex justify-center">登録薬一覧</h1>
-</div>
+   <h1 class="font-bold text-4xl flex justify-center mb-4">登録薬一覧</h1>
 
   <% if @user_medicines.any? %>
     <div class="space-y-4 mb-8">
@@ -29,7 +28,7 @@
                     turbo_method: :delete, 
                     turbo_confirm: "「#{medicine.medicine_name}」を削除してもよろしいですか？\n在庫データも削除されます。" 
                   }, 
-                  class: "btn btn-sm btn-danger" %>
+                  class: "btn btn-sm btn-error" %>
             </div>
           </div>
         </div>
@@ -42,6 +41,6 @@
     </div>
   <% end %>
   <div class="actions text-center">
-    <%= link_to "新しい薬を登録", new_registered_medicine_path, class: "btn btn-primary" %>
+    <%= link_to "新しい薬を登録", new_registered_medicine_path, class: "btn btn-primary" %> 
   </div>
 </div>

--- a/app/views/registered_medicines/index.html.erb
+++ b/app/views/registered_medicines/index.html.erb
@@ -12,23 +12,12 @@
           <p class="text-sm text-gray-600">
             <span class="font-medium">一回の服薬量:</span> <%= medicine.dosage_per_time %>錠
           </p>
-          <p class="text-sm text-gray-600">
-            <span class="font-medium">現在の在庫:</span> <%= medicine.current_stock %>錠
-          </p>
-          <p class="text-sm text-gray-600 whitespace-nowrap overflow-visible">
-            <span class="font-medium">最新の処方日:</span> <%= medicine.date_of_prescription&.strftime('%Y年%m月%d日') %>
-          </p>
         </div>
       </div>
       
       <div class="flex gap-2 ml-4 flex-shrink-0">
-        <%= link_to "編集", edit_registered_medicine_path(medicine), class: "btn btn-sm btn-success" %>
-        <%= link_to "削除", registered_medicine_path(medicine), 
-            data: { 
-              turbo_method: :delete, 
-              turbo_confirm: "「#{medicine.medicine_name}」を削除してもよろしいですか?\n在庫データも削除されます。" 
-            }, 
-            class: "btn btn-sm btn-error" %>
+        <%= link_to "詳細", registered_medicine_path(medicine), class: "btn btn-sm btn-success" %>
+        
       </div>
     </div>
   </div>

--- a/app/views/registered_medicines/index.html.erb
+++ b/app/views/registered_medicines/index.html.erb
@@ -1,38 +1,47 @@
-<div class="container">
-  <h1 class="font-bold text-4xl flex justify-center">いつもの薬リスト</h1>
+<div class="container mx-auto px-4 py-8">
+  <h1 class="font-bold text-4xl flex justify-center">登録薬一覧</h1>
+</div>
 
   <% if @user_medicines.any? %>
-    <table class="table">
-      <thead>
-        <tr>
-          <th>薬名</th>
-          <th>1回の服用量</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @user_medicines.each do |medicine| %>
-          <tr>
-            <td><%= medicine.medicine_name %></td>
-            <td><%= medicine.dosage_per_time %></td>
-            <td>
-              <%= link_to "選択", new_leftover_medicine_path(user_medicine_id: medicine.id), class: "btn btn-sm btn-primary" %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-
-    <div class="flex justify-center mt-4">
-      <%= paginate @user_medicines %>
+    <div class="space-y-4 mb-8">
+      <% @user_medicines.each do |medicine| %>
+        <div class="border rounded-lg p-4 bg-white shadow-sm">
+          <div class="flex justify-between items-start">
+            <div class="flex-1">
+              <h3 class="font-bold text-lg text-gray-900"><%= medicine.medicine_name %></h3>
+              <div class="mt-2 space-y-1">
+                <p class="text-sm text-gray-600">
+                  <span class="font-medium">一回の服薬量:</span> <%= medicine.dosage_per_time %>錠
+                </p>
+                <p class="text-sm text-gray-600">
+                  <span class="font-medium">現在の在庫:</span> <%= medicine.current_stock %>錠
+                </p>
+                <p class="text-sm text-gray-600">
+                  <span class="font-medium">服薬開始日:</span> <%= medicine.date_of_prescription&.strftime('%Y年%m月%d日') %>
+                </p>
+              </div>
+            </div>
+            
+            <div class="flex gap-2 ml-4">
+              <%= link_to "編集", edit_registered_medicine_path(medicine), class: "btn btn-sm btn-success" %>
+              <%= link_to "削除", registered_medicine_path(medicine), 
+                  data: { 
+                    turbo_method: :delete, 
+                    turbo_confirm: "「#{medicine.medicine_name}」を削除してもよろしいですか？\n在庫データも削除されます。" 
+                  }, 
+                  class: "btn btn-sm btn-danger" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
     </div>
-
   <% else %>
-    <p>まだ薬が登録されていません。</p>
+    <div class="text-center py-12">
+      <p class="text-gray-500 mb-4">登録されている薬がありません</p>
+      <%= link_to "最初の薬を登録する", new_registered_medicine_path, class: "btn btn-primary" %>
+    </div>
   <% end %>
-
-  <div class="flex justify-center mt-4">
-    <%= link_to "新しい薬を登録", new_registered_medicine_path, class: "btn bg-white text-[#E56A54] border border-[#E56A54] hover:bg-[#FFE4DF] max-w-xs" %>
+  <div class="actions text-center">
+    <%= link_to "新しい薬を登録", new_registered_medicine_path, class: "btn btn-primary" %>
   </div>
-
 </div>

--- a/app/views/registered_medicines/index.html.erb
+++ b/app/views/registered_medicines/index.html.erb
@@ -3,36 +3,36 @@
 
   <% if @user_medicines.any? %>
     <div class="space-y-4 mb-8">
-      <% @user_medicines.each do |medicine| %>
-        <div class="border rounded-lg p-4 bg-white shadow-sm">
-          <div class="flex justify-between items-start">
-            <div class="flex-1">
-              <h3 class="font-bold text-lg text-gray-900"><%= medicine.medicine_name %></h3>
-              <div class="mt-2 space-y-1">
-                <p class="text-sm text-gray-600">
-                  <span class="font-medium">一回の服薬量:</span> <%= medicine.dosage_per_time %>錠
-                </p>
-                <p class="text-sm text-gray-600">
-                  <span class="font-medium">現在の在庫:</span> <%= medicine.current_stock %>錠
-                </p>
-                <p class="text-sm text-gray-600">
-                  <span class="font-medium">服薬開始日:</span> <%= medicine.date_of_prescription&.strftime('%Y年%m月%d日') %>
-                </p>
-              </div>
-            </div>
-            
-            <div class="flex gap-2 ml-4">
-              <%= link_to "編集", edit_registered_medicine_path(medicine), class: "btn btn-sm btn-success" %>
-              <%= link_to "削除", registered_medicine_path(medicine), 
-                  data: { 
-                    turbo_method: :delete, 
-                    turbo_confirm: "「#{medicine.medicine_name}」を削除してもよろしいですか？\n在庫データも削除されます。" 
-                  }, 
-                  class: "btn btn-sm btn-error" %>
-            </div>
-          </div>
+     <% @user_medicines.each do |medicine| %>
+  <div class="border rounded-lg p-4 bg-white shadow-sm">
+    <div class="flex justify-between items-start">
+      <div class="flex-1 min-w-0 overflow-hidden">
+        <h3 class="font-bold text-lg text-gray-900"><%= medicine.medicine_name %></h3>
+        <div class="mt-2 space-y-1">
+          <p class="text-sm text-gray-600">
+            <span class="font-medium">一回の服薬量:</span> <%= medicine.dosage_per_time %>錠
+          </p>
+          <p class="text-sm text-gray-600">
+            <span class="font-medium">現在の在庫:</span> <%= medicine.current_stock %>錠
+          </p>
+          <p class="text-sm text-gray-600 whitespace-nowrap overflow-visible">
+            <span class="font-medium">最新の処方日:</span> <%= medicine.date_of_prescription&.strftime('%Y年%m月%d日') %>
+          </p>
         </div>
-      <% end %>
+      </div>
+      
+      <div class="flex gap-2 ml-4 flex-shrink-0">
+        <%= link_to "編集", edit_registered_medicine_path(medicine), class: "btn btn-sm btn-success" %>
+        <%= link_to "削除", registered_medicine_path(medicine), 
+            data: { 
+              turbo_method: :delete, 
+              turbo_confirm: "「#{medicine.medicine_name}」を削除してもよろしいですか?\n在庫データも削除されます。" 
+            }, 
+            class: "btn btn-sm btn-error" %>
+      </div>
+    </div>
+  </div>
+<% end %>
     </div>
   <% else %>
     <div class="text-center py-12">

--- a/app/views/registered_medicines/new.html.erb
+++ b/app/views/registered_medicines/new.html.erb
@@ -4,9 +4,15 @@
     <div class="md:w-2/3 w-full">
       <h1 class="font-bold text-4xl">新規作成画面</h1>
 
-      <%= render "form", user_medicine: @user_medicine %>
+      <%= render "form", user_medicine: @user_medicine do |form| %>
+        <div class="inline">
+          <%= form.submit "この内容で追加", class: "btn btn-primary w-full" %>
+        </div>
+      <% end %>
 
-      <%= link_to "登録薬一覧", new_registered_medicine_path, class: "w-full sm:w-auto text-center mt-2 sm:mt-0 sm:ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+      <div class="flex justify-center mt-4">
+        <%= link_to "登録薬一覧", new_registered_medicine_path, class: "w-full sm:w-auto text-center mt-2 sm:mt-0 sm:ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/registered_medicines/select.html.erb
+++ b/app/views/registered_medicines/select.html.erb
@@ -1,0 +1,32 @@
+<div class="container mx-auto px-4 py-8">
+  <h1 class="font-bold text-4xl flex justify-center">いつもの薬リスト</h1>
+  <p class="text-gray-600 mb-4 text-center">登録済みの薬から処方薬を追加できます</p>
+  
+  <% if @user_medicines.any? %>
+   <div class="space-y-4">
+     <% @user_medicines.each do |medicine| %>
+       <div class="border rounded-lg p-4 bg-white shadow-sm">
+         <div class="flex justify-between">
+           <div>
+             <h3 class="font-bold text-lg text-gray-900"><%= medicine.medicine_name %></h3>
+             <p class="text-sm text-gray-600 mt-1">1回の服用量: <%= medicine.dosage_per_time %></p>
+           </div>
+           <div class="ml-4">
+             <%= link_to "選択", new_leftover_medicine_path(user_medicine_id: medicine.id), class: "btn btn-primary" %>
+           </div>
+         </div>
+       </div>
+  <% end %>
+  </div>
+  <div class="flex justify-center mt-4">
+    <%= paginate @user_medicines %>
+  </div>
+
+  <% else %>
+    <p class="text-center text-gray-500">まだ薬が登録されていません。</p>
+  <% end %>
+
+  <div class="flex justify-center mt-4">
+    <%= link_to "新しい薬を登録", new_registered_medicine_path, class: "btn bg-white text-[#E56A54] border border-[#E56A54] hover:bg-[#FFE4DF] max-w-xs" %>
+  </div>
+</div>

--- a/app/views/registered_medicines/select.html.erb
+++ b/app/views/registered_medicines/select.html.erb
@@ -3,24 +3,25 @@
   <p class="text-gray-600 mb-4 text-center">登録済みの薬から処方薬を追加できます</p>
   
   <% if @user_medicines.any? %>
-   <div class="space-y-4">
-     <% @user_medicines.each do |medicine| %>
-       <div class="border rounded-lg p-4 bg-white shadow-sm">
-         <div class="flex justify-between">
-           <div>
-             <h3 class="font-bold text-lg text-gray-900"><%= medicine.medicine_name %></h3>
-             <p class="text-sm text-gray-600 mt-1">1回の服用量: <%= medicine.dosage_per_time %></p>
-           </div>
-           <div class="ml-4">
-             <%= link_to "選択", new_leftover_medicine_path(user_medicine_id: medicine.id), class: "btn btn-primary" %>
-           </div>
-         </div>
-       </div>
-  <% end %>
-  </div>
-  <div class="flex justify-center mt-4">
-    <%= paginate @user_medicines %>
-  </div>
+    <div class="space-y-4">
+      <% @user_medicines.each do |medicine| %>
+        <div class="border rounded-lg bg-white shadow-sm overflow-hidden">
+          <div class="flex items-center">
+            <div class="px-6 py-4 flex-1">
+              <h3 class="font-bold text-lg text-gray-900"><%= medicine.medicine_name %></h3>
+              <p class="text-sm text-gray-600 mt-1">1回の服用量: <%= medicine.dosage_per_time %></p>
+            </div>
+          <div class="px-6 py-4 text-right">
+            <%= link_to "選択", new_leftover_medicine_path(user_medicine_id: medicine.id), class: "btn btn-sm btn-primary" %>
+        </div>
+      </div>
+    </div>
+      <% end %>
+    </div>
+    
+    <div class="flex justify-center mt-4">
+      <%= paginate @user_medicines %>
+    </div>
 
   <% else %>
     <p class="text-center text-gray-500">まだ薬が登録されていません。</p>

--- a/app/views/registered_medicines/show.html.erb
+++ b/app/views/registered_medicines/show.html.erb
@@ -1,15 +1,18 @@
-<% content_for :title, "Showing user medicine" %>
-
-<div class="md:w-2/3 w-full">
-  <% if notice.present? %>
-    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%= notice %></p>
-  <% end %>
-
-  <h1 class="font-bold text-4xl">Showing user medicine</h1>
+<div class="container mx-auto px-4 py-8">
+   <h1 class="font-bold text-4xl flex justify-center mb-4">登録薬詳細</h1>
 
   <%= render @user_medicine %>
 
-  <%= link_to "Edit this user medicine", edit_registered_medicine_path(@user_medicine), class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-  <%= link_to "Back to user medicines", registered_medicines_path, class: "w-full sm:w-auto text-center mt-2 sm:mt-0 sm:ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-  <%= button_to "Destroy this user medicine", registered_medicine_path(@user_medicine), method: :delete, class: "rounded-md px-3.5 py-2.5 text-white bg-red-600 hover:bg-red-500 font-medium cursor-pointer" %>
+  <%= link_to "編集", edit_registered_medicine_path(@user_medicine), class: "btn btn btn-success w-full" %>
+  <div class="flex justify-center mt-4">
+    <%= link_to "登録薬一覧", registered_medicines_path, class: "btn bg-white text-[#E56A54] border border-[#E56A54] hover:bg-[#FFE4DF] max-w-xs mb-8" %>
+  </div>
+  <div class="actions text-center">
+    <%= link_to "削除", registered_medicine_path(@user_medicine), 
+              data: { 
+                turbo_method: :delete, 
+                turbo_confirm: "「#{@user_medicine.medicine_name}」を削除してもよろしいですか?\n在庫データも削除されます。" 
+              }, 
+              class: "btn btn-sm btn-error" %>
+  </div>
 </div>

--- a/app/views/shared/_drawer_menu.html.erb
+++ b/app/views/shared/_drawer_menu.html.erb
@@ -1,7 +1,7 @@
 <div class="drawer-side">
   <label for="drawer-menu" class="drawer-overlay"></label>
     <ul class="menu p-4 w-80 bg-base-100">
-      <li><%= link_to '登録薬一覧', "#" %></li>
+      <li><%= link_to '登録薬一覧', registered_medicines_path %></li>
       <li><%= link_to '残薬一覧', "#" %></li>
     </ul>
 </div>

--- a/app/views/user_medicines/_user_medicine.html.erb
+++ b/app/views/user_medicines/_user_medicine.html.erb
@@ -1,24 +1,24 @@
-<div class="user-medicine-card bg-white shadow-md rounded-lg p-6">
+<div class="user-medicine-card bg-white shadow-md rounded-lg p-6 mb-4">
   <h2 class="text-2xl font-bold mb-4"><%= user_medicine.medicine_name %></h2>
   
   <dl class="grid grid-cols-1 md:grid-cols-2 gap-4">
     <div>
       <dt class="font-semibold text-gray-700">1回の服用量</dt>
-      <dd class="text-gray-900 mt-1"><%= user_medicine.dosage_per_time %></dd>
+      <dd class="text-gray-900 mt-1"><%= user_medicine.dosage_per_time %>錠</dd>
     </div>
     
     <div>
       <dt class="font-semibold text-gray-700">処方量</dt>
-      <dd class="text-gray-900 mt-1"><%= user_medicine.prescribed_amount %></dd>
+      <dd class="text-gray-900 mt-1"><%= user_medicine.prescribed_amount %>錠</dd>
     </div>
     
     <div>
       <dt class="font-semibold text-gray-700">現在の残数</dt>
-      <dd class="text-gray-900 mt-1"><%= user_medicine.current_stock %></dd>
+      <dd class="text-gray-900 mt-1"><%= user_medicine.current_stock %>錠</dd>
     </div>
     
     <div>
-      <dt class="font-semibold text-gray-700">処方日</dt>
+      <dt class="font-semibold text-gray-700">最新の処方日</dt>
       <dd class="text-gray-900 mt-1">
         <%= l(user_medicine.date_of_prescription, format: :long) if user_medicine.date_of_prescription.present? %>
       </dd>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
   resources :leftover_medicines
-  resources :registered_medicines
+  resources :registered_medicines do
+    collection do
+      get :select  # 処方箋追加用の選択画面
+  end
+  end
   devise_for :users, controllers: {
     registrations: "users/registrations"
   }


### PR DESCRIPTION
### 概要

[#33]
登録薬の詳細画面と編集画面を作成しました。

### 作業内容

- registered_medicines/show.html.erbを編集
- registered_medicines/edit.html.erbを編集

### 機能追加理由

登録した薬の詳細情報を見て、編集機能で登録間違い時に変更できるため。

### 備考

登録薬といつもの薬リストを混同してしまうため、別issueで実装を変更します。[#34][#35]
今回の実装は変更予定ですが、記録のためにpushしています。