### PR TITLE
【Feature】

### DIFF
--- a/app/controllers/user_medicines_controller.rb
+++ b/app/controllers/user_medicines_controller.rb
@@ -1,6 +1,7 @@
 class UserMedicinesController < ApplicationController
   def index
     @user_medicines = current_user.user_medicines.where("current_stock > 0").order(date_of_prescription: :desc)
+    @date = params[:date]&.to_date || Date.current
   end
 
   # 薬選択画面

--- a/app/models/user_medicine.rb
+++ b/app/models/user_medicine.rb
@@ -8,4 +8,11 @@ class UserMedicine < ApplicationRecord
 
   # 単発の薬を取得(本リリースで使用予定)
   scope :temporary_medicines, -> { where(is_regular: false) }
+
+  # カレンダーの日付を押した時の予想在庫数計算
+  def stock_on(date)
+    days_diff = (date - Date.current).to_i
+    estimated = current_stock - days_diff * dosage_per_time
+    [ estimated, 0 ].max
+  end
 end

--- a/app/views/user_medicines/_stock_modal.html.erb
+++ b/app/views/user_medicines/_stock_modal.html.erb
@@ -1,4 +1,4 @@
-<div class="modal modal-open fixed inset-0 z-50">
+<div class="modal modal-open">
   <div class="modal-box">
     <h3 class="font-bold text-lg">
       <%= @date %> の在庫予定
@@ -7,7 +7,7 @@
     <% @user_medicines.each do |medicine| %>
       <p>
         <%= medicine.medicine_name %>：
-        <%= medicine.stock_on(@date) %> 錠
+        残り<%= medicine.stock_on(@date) %> 錠
       </p>
     <% end %>
 

--- a/app/views/user_medicines/_stock_modal.html.erb
+++ b/app/views/user_medicines/_stock_modal.html.erb
@@ -1,0 +1,20 @@
+<div class="modal modal-open fixed inset-0 z-50">
+  <div class="modal-box">
+    <h3 class="font-bold text-lg">
+      <%= @date %> の在庫予定
+    </h3>
+
+    <% @user_medicines.each do |medicine| %>
+      <p>
+        <%= medicine.medicine_name %>：
+        <%= medicine.stock_on(@date) %> 錠
+      </p>
+    <% end %>
+
+    <div class="modal-action">
+      <%= link_to "閉じる",
+            user_medicines_path,
+            class: "btn" %>
+    </div>
+  </div>
+</div>

--- a/app/views/user_medicines/index.html.erb
+++ b/app/views/user_medicines/index.html.erb
@@ -25,10 +25,17 @@
   <!-- カレンダー表示エリア -->
   <div class="calendar-section max-w-4xl mx-auto mb-8">
     <%= month_calendar do |date| %>
-      <%= date.day %>
+      <%= link_to date.day, user_medicines_path(date: date) %>
     <% end %>
       <!-- 後で服薬予定などを表示 -->
-  </div>
+    <h2><%= @date %> の在庫予定</h2>
+    <% @user_medicines.each do |medicine| %>
+    <p>
+      <%= medicine.medicine_name %>：
+      <%= medicine.stock_on(@date) %> 錠
+    </p>
+    </div>
+    <% end %>
 
   <!-- 登録薬管理へのリンク -->
   <div class="actions text-center">

--- a/app/views/user_medicines/index.html.erb
+++ b/app/views/user_medicines/index.html.erb
@@ -25,20 +25,22 @@
   <!-- カレンダー表示エリア -->
   <div class="calendar-section max-w-4xl mx-auto mb-8">
     <%= month_calendar do |date| %>
-      <%= link_to date.day, user_medicines_path(date: date) %>
+      <%= link_to date.day,
+        user_medicines_path(date: date),
+        data: { turbo_frame: "stock_modal" } %>
     <% end %>
-      <!-- 後で服薬予定などを表示 -->
-    <h2><%= @date %> の在庫予定</h2>
-    <% @user_medicines.each do |medicine| %>
-    <p>
-      <%= medicine.medicine_name %>：
-      <%= medicine.stock_on(@date) %> 錠
-    </p>
-    </div>
-    <% end %>
+  </div>
 
   <!-- 登録薬管理へのリンク -->
   <div class="actions text-center">
     <%= link_to "薬の追加", select_medicine_user_medicines_path, class: "btn btn-primary" %>
   </div>
+
+  <!-- モーダル枠 -->
+  <turbo-frame id="stock_modal">
+    <% if params[:date].present? %>
+      <%= render "stock_modal" %>
+    <% end %>
+  </turbo-frame>
+
 </div>


### PR DESCRIPTION
### 概要

[#22]
カレンダーの日付を選択するとその日の予想在庫量をモーダルで表示する実装をしました。

### 作業内容

**在庫計算ロジック**
1. UserMedicinesモデル
在庫計算ロジックのstock_on(date)を記述

**カレンダーの日付選択**
1. user_medicines_controller.rb
@dateに選択した日付を渡す記述

2. user_medicines/index.html
日付をクリックしたらuser_medicines_path(date: date)にリンクが飛ぶ記述

**モーダル**
1. user_medicines/index.html
クリックしたら部分テンプレートに遷移する記述

2. user_medicines/_stock_modal.html.erb
モーダルの中身を記述

### 機能追加理由

選択した日の予想在庫量を確認できることで通院の目処を立てやすくするため。
モーダル表示にすることで画面を遷移することなくすぐに確認できるようにした。
