### PR TITLE
【feature】カレンダー上に残り10錠の薬を表示する

### DIFF
--- a/app/views/user_medicines/index.html.erb
+++ b/app/views/user_medicines/index.html.erb
@@ -28,6 +28,16 @@
       <%= link_to date.day,
         user_medicines_path(date: date),
         data: { turbo_frame: "stock_modal" } %>
+
+      <!-- カレンダー上の残り10錠表示 -->
+      <% @user_medicines.each do |medicine| %>
+        <% stock = medicine.stock_on(date) %>
+        <% if stock == 10 %>
+          <span class="block text-xs text-error">
+            <%= medicine.medicine_name %>：残り10錠
+          </span>
+        <% end %>
+      <% end %>
     <% end %>
   </div>
 


### PR DESCRIPTION
### 概要

[#23]
カレンダー上に残り10錠の薬を表示しました。

### 作業内容

1. user_medicines/index.html.erb
在庫が10の薬の名前と残り10錠という表示がされる記述

### 機能追加理由

通院計画を立てる目安になるように残り10錠をカレンダーに表示して一目で確認できるようにするため。
