### PR TITLE
【Bugfix】薬登録時のバリデーション追加

### DIFF
--- a/app/controllers/user_medicines_controller.rb
+++ b/app/controllers/user_medicines_controller.rb
@@ -15,7 +15,7 @@ class UserMedicinesController < ApplicationController
 
   def create
     @user_medicine = current_user.user_medicines.build(user_medicine_params)
-Rails.logger.debug "params[:user_medicine][:dosage_per_time] = #{params[:user_medicine][:dosage_per_time].inspect}"
+
     # 処方量を在庫として設定(手元に在庫がない初回登録時用)
     @user_medicine.current_stock = @user_medicine.prescribed_amount
 

--- a/app/controllers/user_medicines_controller.rb
+++ b/app/controllers/user_medicines_controller.rb
@@ -15,7 +15,7 @@ class UserMedicinesController < ApplicationController
 
   def create
     @user_medicine = current_user.user_medicines.build(user_medicine_params)
-
+Rails.logger.debug "params[:user_medicine][:dosage_per_time] = #{params[:user_medicine][:dosage_per_time].inspect}"
     # 処方量を在庫として設定(手元に在庫がない初回登録時用)
     @user_medicine.current_stock = @user_medicine.prescribed_amount
 

--- a/app/controllers/user_medicines_controller.rb
+++ b/app/controllers/user_medicines_controller.rb
@@ -58,7 +58,7 @@ class UserMedicinesController < ApplicationController
       :medicine_name,
       :dosage_per_time,
       :prescribed_amount,
-      :date_of_prescription,
+      :date_of_prescription
     )
   end
 end

--- a/app/models/user_medicine.rb
+++ b/app/models/user_medicine.rb
@@ -1,7 +1,11 @@
 class UserMedicine < ApplicationRecord
   belongs_to :user
 
-  validates :prescribed_amount, presence: true, numericality: { greater_than: 0 }
+  validates :medicine_name, presence: true
+
+  validates :dosage_per_time, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_blank: true }
+
+  validates :prescribed_amount, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_blank: true }
 
   # いつもの薬リストに表示する薬を取得
   scope :regular_medicines, -> { where(is_regular: true) }

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div class="error-messages alert alert-danger">
+    <ul class="mb-0">
+      <% object.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/user_medicines/add_stock.html.erb
+++ b/app/views/user_medicines/add_stock.html.erb
@@ -4,9 +4,9 @@
       <h1 class="font-bold text-4xl text-center mb-6">在庫追加</h1>
 
       <div class="bg-white rounded-lg shadow p-6">
-        <%= form_with model: @user_medicine,
+        <%= form_with(model: @user_medicine,
                       url: update_stock_user_medicine_path(@user_medicine),
-                      method: :patch do |f| %>
+                      method: :patch) do |f| %>
           <%= render 'shared/error_messages', object: f.object %>
 
           <!-- 薬名(表示のみ) -->
@@ -37,17 +37,12 @@
           <div class="mb-4">
             <%= f.label :prescribed_amount, "処方量", class: "block text-sm font-bold mb-2" %>
             <div class="flex items-center">
-              <%= f.number_field :prescribed_amount,
+              <%= f.text_field :prescribed_amount,
                   placeholder: "追加する数量を入力",
-                  min: 1,
+                  type: "number",
                   class: "flex-1 border border-gray-300 rounded px-3 py-2" %>
               <span class="ml-2 text-gray-700">錠</span>
             </div>
-            <% if @user_medicine.errors[:prescribed_amount].any? %>
-              <p class="text-red-500 text-sm mt-1">
-                <%= @user_medicine.errors[:prescribed_amount].first %>
-              </p>
-            <% end %>
           </div>
 
           <!-- 処方日(入力) -->

--- a/app/views/user_medicines/add_stock.html.erb
+++ b/app/views/user_medicines/add_stock.html.erb
@@ -7,6 +7,7 @@
         <%= form_with model: @user_medicine,
                       url: update_stock_user_medicine_path(@user_medicine),
                       method: :patch do |f| %>
+          <%= render 'shared/error_messages', object: f.object %>
 
           <!-- 薬名(表示のみ) -->
           <div class="mb-4">

--- a/app/views/user_medicines/new.html.erb
+++ b/app/views/user_medicines/new.html.erb
@@ -5,6 +5,7 @@
 
       <div class="bg-white rounded-lg shadow p-6">
         <%= form_with(model: @user_medicine, class: "contents") do |f| %>
+          <%= render 'shared/error_messages', object: f.object %>
 
           <!-- 薬名(表示のみ) -->
           <div class="mb-4">
@@ -33,11 +34,6 @@
                   class: "flex-1 border border-gray-300 rounded px-3 py-2" %>
               <span class="ml-2 text-gray-700">錠</span>
             </div>
-            <% if @user_medicine.errors[:prescribed_amount].any? %>
-              <p class="text-red-500 text-sm mt-1">
-                <%= @user_medicine.errors[:prescribed_amount].first %>
-              </p>
-            <% end %>
           </div>
 
           <!-- 処方日(入力) -->

--- a/app/views/user_medicines/new.html.erb
+++ b/app/views/user_medicines/new.html.erb
@@ -46,7 +46,7 @@
 
           <!-- 送信ボタン -->
           <div class="text-center gap-4">
-            <%= f.submit "在庫を追加",
+            <%= f.submit "薬を追加",
                 class: "btn btn-primary" %>
           </div>
         <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,16 @@
 ja:
+  activerecord:
+    attributes:
+      user_medicine:
+        medicine_name: "薬名"
+        dosage_per_time: "1回の服薬量"
+        prescribed_amount: "処方量"
+    errors:
+      models:
+        medicine:
+          attributes:
+            medicine_name:
+              blank: "を入力してください"
   date:
     formats:
       default: "%Y/%m/%d"


### PR DESCRIPTION
### 概要

[#57]
薬を登録する際のフォームを空で送信した際のバリデーションエラーを表示する実装をしました。

### 作業内容

1. shared/error_messages.html.erb
エラーメッセージをテンプレート化してこのファイルに切り出す

2. config/ja.yml
エラーメッセージが日本語になるようUserMedicinesモデルのカラムの日本語を設定

3. model/user_medicines.rb
1回の服薬量と処方量のカラムに空欄を許可しない、1以上の整数であるバリデーションを追加

4. user_medicines/add_stock.html.erb
空の場合のバリデーションが効くようにassign_attributeを追加

### 機能追加理由

フォームの入力が正しくない場合に、何が正しくないのかをユーザーに伝えることで使いやすくするため。
