### PR TITLE
【Bugfix】処方日前の残り10錠の表示を修正する

### DIFF
--- a/app/controllers/user_medicines_controller.rb
+++ b/app/controllers/user_medicines_controller.rb
@@ -2,6 +2,11 @@ class UserMedicinesController < ApplicationController
   def index
     @user_medicines = current_user.user_medicines.where("current_stock > 0").order(date_of_prescription: :desc)
     @date = params[:date]&.to_date || Date.current
+
+    # 在庫がある薬だけに絞り込む
+    @medicines_with_stock = @user_medicines.select do |medicine|
+      medicine.stock_on(@date) > 0
+    end
   end
 
   # 薬選択画面

--- a/app/models/user_medicine.rb
+++ b/app/models/user_medicine.rb
@@ -15,6 +15,9 @@ class UserMedicine < ApplicationRecord
 
   # カレンダーの日付を押した時の予想在庫数計算
   def stock_on(date)
+    # 処方日より前の日付の場合は計算しない
+    return 0 if date < date_of_prescription
+
     days_diff = (date - Date.current).to_i
     estimated = current_stock - days_diff * dosage_per_time
     [ estimated, 0 ].max

--- a/app/views/user_medicines/_stock_modal.html.erb
+++ b/app/views/user_medicines/_stock_modal.html.erb
@@ -4,7 +4,7 @@
       <%= @date %> の在庫予定
     </h3>
 
-    <% @user_medicines.each do |medicine| %>
+    <% @medicines_with_stock.each do |medicine| %>
       <p>
         <%= medicine.medicine_name %>：
         残り<%= medicine.stock_on(@date) %> 錠

--- a/app/views/user_medicines/_stock_modal.html.erb
+++ b/app/views/user_medicines/_stock_modal.html.erb
@@ -4,10 +4,17 @@
       <%= @date %> の在庫予定
     </h3>
 
-    <% @medicines_with_stock.each do |medicine| %>
-      <p>
-        <%= medicine.medicine_name %>：
-        残り<%= medicine.stock_on(@date) %> 錠
+    <% medicines_with_stock = @user_medicines.select { |m| m.stock_on(@date) > 0 } %>
+    <% if medicines_with_stock.any? %>
+      <% medicines_with_stock.each do |medicine| %>
+        <p>
+          <%= medicine.medicine_name %>：
+          残り<%= medicine.stock_on(@date) %> 錠
+        </p>
+      <% end %>
+    <% else %>
+      <p class="text-gray-500">
+        この日は在庫がありません
       </p>
     <% end %>
 

--- a/app/views/user_medicines/_stock_modal.html.erb
+++ b/app/views/user_medicines/_stock_modal.html.erb
@@ -4,9 +4,8 @@
       <%= @date %> の在庫予定
     </h3>
 
-    <% medicines_with_stock = @user_medicines.select { |m| m.stock_on(@date) > 0 } %>
-    <% if medicines_with_stock.any? %>
-      <% medicines_with_stock.each do |medicine| %>
+    <% if @medicines_with_stock.any? %>
+      <% @medicines_with_stock.each do |medicine| %>
         <p>
           <%= medicine.medicine_name %>：
           残り<%= medicine.stock_on(@date) %> 錠

--- a/app/views/user_medicines/index.html.erb
+++ b/app/views/user_medicines/index.html.erb
@@ -31,7 +31,7 @@
       <!-- カレンダー上の残り10錠表示 -->
       <% @user_medicines.each do |medicine| %>
         <% stock = medicine.stock_on(date) %>
-        <% if medicine.current_stock > 10 && stock == 10 %>
+        <% if stock == 10 %>
           <span class="block text-xs text-error">
             <%= medicine.medicine_name %>：残り10錠
           </span>

--- a/app/views/user_medicines/index.html.erb
+++ b/app/views/user_medicines/index.html.erb
@@ -10,9 +10,8 @@
       <table class="table w-full bg-white shadow-md rounded-lg overflow-hidden">
         <tbody>
           <% @user_medicines.each do |user_medicine| %>
-            <tr class="border-b hover:bg-gray-50">
+            <tr class="border-b">
               <td class="px-6 py-4"><%= user_medicine.medicine_name %></td>
-              <td class="px-6 py-4 text-right">残り<%= user_medicine.current_stock %>錠</td>
             </tr>
           <% end %>
         </tbody>
@@ -32,7 +31,7 @@
       <!-- カレンダー上の残り10錠表示 -->
       <% @user_medicines.each do |medicine| %>
         <% stock = medicine.stock_on(date) %>
-        <% if stock == 10 %>
+        <% if medicine.current_stock > 10 && stock == 10 %>
           <span class="block text-xs text-error">
             <%= medicine.medicine_name %>：残り10錠
           </span>


### PR DESCRIPTION
### 概要

[#60]
カレンダー上の残り10錠の表示と日付を押した際のその日の在庫量の表示を修正しました

### 作業内容
  
- 処方日前の日付を選択すると処方日との差を計算して架空の手元在庫を表示してしまう
  - model/user_medicines.rb
stock_onメソッドに処方日より前の日付の場合は計算しないロジックを記述

- 残り10錠の表示は処方量が10以上の薬を登録した場合にのみ適用と変更する。
 → 処方日より前の日付の場合は計算しないことで解決

- 在庫が0の薬はモーダルに表示しない
  - user_medicines_controller.rb
  在庫がある薬だけを取得する変数を定義
  - user_medicines/_stock_modal.html.erb
  変数を受け取り、在庫がある場合のみ表示

### 備考

MVPでは自動減算昨日は実装しないため、カレンダーの上の今日の薬一覧の在庫量と、カレンダーの日付を押した時の在庫量に相違があったため、薬一覧の在庫量は削除しました。