### PR TITLE
【change】unprocessable_entityをunprocessable_contentに書き換えた

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", require: false
+  gem "brakeman", "7.1.2", require: false
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.19.0)
       msgpack (~> 1.2)
-    brakeman (7.1.1)
+    brakeman (7.1.2)
       racc
     builder (3.3.0)
     byebug (12.0.0)
@@ -377,7 +377,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
-  brakeman
+  brakeman (= 7.1.2)
   capybara
   debug
   devise (= 4.9.4)

--- a/app/controllers/user_medicines_controller.rb
+++ b/app/controllers/user_medicines_controller.rb
@@ -27,7 +27,7 @@ class UserMedicinesController < ApplicationController
       if @user_medicine.save
         redirect_to user_medicines_path, notice: "薬を登録しました"
       else
-        render :new, status: :unprocessable_content
+        render :new, status: :unprocessable_entiry
       end
   end
 
@@ -52,7 +52,7 @@ class UserMedicinesController < ApplicationController
       @user_medicine.save
       redirect_to user_medicines_path, notice: "薬を追加しました"
     else
-      render :add_stock, status: :unprocessable_content
+      render :add_stock, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/user_medicines_controller.rb
+++ b/app/controllers/user_medicines_controller.rb
@@ -27,7 +27,7 @@ class UserMedicinesController < ApplicationController
       if @user_medicine.save
         redirect_to user_medicines_path, notice: "薬を登録しました"
       else
-        render :new, status: :unprocessable_entity
+        render :new, status: :unprocessable_content
       end
   end
 
@@ -52,7 +52,7 @@ class UserMedicinesController < ApplicationController
       @user_medicine.save
       redirect_to user_medicines_path, notice: "薬を追加しました"
     else
-      render :add_stock, status: :unprocessable_entity
+      render :add_stock, status: :unprocessable_content
     end
   end
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -302,7 +302,7 @@ Devise.setup do |config|
   # apps is `200 OK` and `302 Found` respectively, but new apps are generated with
   # these new defaults that match Hotwire/Turbo behavior.
   # Note: These might become the new default in future versions of Devise.
-  config.responder.error_status = :unprocessable_entity
+  config.responder.error_status = :unprocessable_content
   config.responder.redirect_status = :see_other
 
   # ==> Configuration for :registerable


### PR DESCRIPTION
### 概要

[#28]
unprocessable_entityがdeviseの中で警告が出るのでunprocessable_contentに書き換えました。

### 作業内容

1. config/initializer.rbのunprocessable_entityをunprocessable_contentに書き換え

### 修正理由

仕様変更のため、unprocessable_entityではログにエラーが出ており、将来的に使われなくなるため、指示通りにunprocessable_contentに書き換えました。

