### PR TITLE
【change】with_current_stockメソッドを作成、在庫量のバグ修正

### DIFF
--- a/app/controllers/user_medicines_controller.rb
+++ b/app/controllers/user_medicines_controller.rb
@@ -3,10 +3,7 @@ class UserMedicinesController < ApplicationController
     @user_medicines = current_user.user_medicines.where("current_stock > 0").order(date_of_prescription: :desc)
     @date = params[:date]&.to_date || Date.current
 
-    # 在庫がある薬だけに絞り込む
-    @medicines_with_stock = @user_medicines.select do |medicine|
-      medicine.stock_on(@date) > 0
-    end
+    @medicines_with_stock = current_user.user_medicines.with_current_stock
   end
 
   # 薬選択画面

--- a/app/models/user_medicine.rb
+++ b/app/models/user_medicine.rb
@@ -13,13 +13,14 @@ class UserMedicine < ApplicationRecord
   # 単発の薬を取得(本リリースで使用予定)
   scope :temporary_medicines, -> { where(is_regular: false) }
 
+  scope :with_current_stock, -> { where("current_stock > 0") }
+
   # カレンダーの日付を押した時の予想在庫数計算
   def stock_on(date)
     # 処方日より前の日付の場合は計算しない
     return 0 if date < date_of_prescription
 
-    days_diff = (date - Date.current).to_i
+    days_diff = (date - date_of_prescription).to_i
     estimated = current_stock - days_diff * dosage_per_time
-    [ estimated, 0 ].max
   end
 end


### PR DESCRIPTION
### 概要

[#48]
モデルにwith_current_stockをスコープで切り出しコントローラーをスッキリさせました。
[#65]
在庫量のバグを修正しました。

### 作業内容

1. with_current_stockメソッドを作成

- model/user_medicines.rbにwith_current_stockをスコープに定義
- コントローラーで呼び出す記述

2. 在庫量のバグ修正

- model/user_medicines.rb
今日との日数差ではなく、処方日との日数差で計算するよう修正

