### PR TITLE
【Bugfix】処方日と登録日が異なる場合の在庫量の計算を正しく行う

### DIFF
--- a/app/controllers/user_medicines_controller.rb
+++ b/app/controllers/user_medicines_controller.rb
@@ -17,9 +17,7 @@ class UserMedicinesController < ApplicationController
 
   def create
     @user_medicine = current_user.user_medicines.build(user_medicine_params)
-
-    # 処方量を在庫として設定(手元に在庫がない初回登録時用)
-    @user_medicine.current_stock = @user_medicine.prescribed_amount
+    @user_medicine.current_stock = @user_medicine.initial_stock_on_create
 
       if @user_medicine.save
         redirect_to user_medicines_path, notice: "薬を登録しました"

--- a/app/models/user_medicine.rb
+++ b/app/models/user_medicine.rb
@@ -15,7 +15,7 @@ class UserMedicine < ApplicationRecord
   # 単発の薬を取得(本リリースで使用予定)
   scope :temporary_medicines, -> { where(is_regular: false) }
 
-  scope :with_current_stock, -> { where("current_stock > 0") }
+  scope :with_current_stock, -> { where("current_stock > 0").order(created_at: :desc) }
 
   # カレンダーの日付を押した時の予想在庫数計算
   def stock_on(date)

--- a/app/models/user_medicine.rb
+++ b/app/models/user_medicine.rb
@@ -27,6 +27,7 @@ class UserMedicine < ApplicationRecord
     [ estimated, 0 ].max
   end
 
+  # 初回登録時、処方日と登録日が異なる場合の在庫量の計算
   def initial_stock_on_create
     return prescribed_amount if date_of_prescription == Date.current
 

--- a/app/models/user_medicine.rb
+++ b/app/models/user_medicine.rb
@@ -15,7 +15,7 @@ class UserMedicine < ApplicationRecord
   # 単発の薬を取得(本リリースで使用予定)
   scope :temporary_medicines, -> { where(is_regular: false) }
 
-  scope :with_current_stock, -> { where("current_stock > 0").order(created_at: :desc) }
+  scope :with_current_stock, -> { where("current_stock > 0").order(created_at: :asc) }
 
   # カレンダーの日付を押した時の予想在庫数計算
   def stock_on(date)

--- a/app/models/user_medicine.rb
+++ b/app/models/user_medicine.rb
@@ -19,10 +19,9 @@ class UserMedicine < ApplicationRecord
 
   # カレンダーの日付を押した時の予想在庫数計算
   def stock_on(date)
-    # 処方日より前の日付の場合は計算しない
-    return 0 if date < date_of_prescription
-
-    days_diff = (date - date_of_prescription).to_i
+    days_diff = (date - Date.current).to_i
     estimated = current_stock - days_diff * dosage_per_time
+    # 在庫量がマイナス表示されないようにする
+    [ estimated, 0 ].max
   end
 end

--- a/app/views/user_medicines/_stock_modal.html.erb
+++ b/app/views/user_medicines/_stock_modal.html.erb
@@ -3,8 +3,11 @@
     <h3 class="font-bold text-lg">
       <%= @date %> の在庫予定
     </h3>
-
-    <% if @medicines_with_stock.any? %>
+    <% if @date < Date.current %>
+      <p class="text-gray-500">
+        今日より前の日付の在庫は表示できません。
+      </p>
+    <% elsif @medicines_with_stock.any? %>
       <% @medicines_with_stock.each do |medicine| %>
         <p>
           <%= medicine.medicine_name %>：

--- a/app/views/user_medicines/add_stock.html.erb
+++ b/app/views/user_medicines/add_stock.html.erb
@@ -50,6 +50,7 @@
             <%= f.label :date_of_prescription, "処方日", class: "block text-sm font-bold mb-2" %>
             <%= f.date_field :date_of_prescription,
                 value: Date.today,
+                max: Date.today,
                 class: "w-full border border-gray-300 rounded px-3 py-2" %>
           </div>
 

--- a/app/views/user_medicines/index.html.erb
+++ b/app/views/user_medicines/index.html.erb
@@ -12,6 +12,7 @@
           <% @user_medicines.each do |user_medicine| %>
             <tr class="border-b">
               <td class="px-6 py-4"><%= user_medicine.medicine_name %></td>
+              <td class="px-6 py-4 text-right">残り<%= user_medicine.current_stock %>錠</td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/user_medicines/index.html.erb
+++ b/app/views/user_medicines/index.html.erb
@@ -6,10 +6,10 @@
       <%= l(Date.today, format: :long) %>
     </h2>
 
-    <% if @user_medicines.any? %>
+    <% if @medicines_with_stock.any? %>
       <table class="table w-full bg-white shadow-md rounded-lg overflow-hidden">
         <tbody>
-          <% @user_medicines.each do |user_medicine| %>
+          <% @medicines_with_stock.each do |user_medicine| %>
             <tr class="border-b">
               <td class="px-6 py-4"><%= user_medicine.medicine_name %></td>
               <td class="px-6 py-4 text-right">残り<%= user_medicine.current_stock %>錠</td>
@@ -18,7 +18,7 @@
         </tbody>
       </table>
     <% else %>
-      <p class="text-center text-gray-500 py-8">現在、残薬はありません。</p>
+      <p class="text-center text-gray-500 py-8">現在、薬はありません。</p>
     <% end %>
   </div>
 

--- a/app/views/user_medicines/new.html.erb
+++ b/app/views/user_medicines/new.html.erb
@@ -41,6 +41,7 @@
             <%= f.label :date_of_prescription, "処方日", class: "block text-sm font-bold mb-2" %>
             <%= f.date_field :date_of_prescription,
                 value: Date.today,
+                max: Date.today,
                 class: "w-full border border-gray-300 rounded px-3 py-2" %>
           </div>
 


### PR DESCRIPTION
### 概要

[#117]
処方日と登録日が異なる場合の在庫量の計算を正しく行うように修正しました。

### 作業内容

**在庫量の計算**
1. models/user_medicines.rb
処方日が登録日より過去の場合、服薬したものとして登録日時点の在庫量を計算するメソッドを記述
2. user_medicines_controller.rb #create
1のメソッドを呼び出す記述

**処方日に未来の日付は選択できないようにする**
1. models/user_medicines.rb
date_of_prescription_cannot_be_in_futureを定義して、処方日は未来を登録できないようにバリデーションを追加

2. user_medicines/new.html.erbとadd_stock.html.erb
処方日を登録するフォームで未来の日付が選択できないようにmax属性を追加

**過去の在庫量はモーダルに表示できないようにする**
1.  models/user_medicines.rb
今日と選択した日の日数差で在庫量を計算するように編集

2.  _stock_modeal.html.erb
今日より前の日付が選択されたら、「今日より前の日付は表示できません」と表示する条件分岐を記述

