### PR TITLE
【Feature】URLにidの代わりにuuidを表示する

### DIFF
--- a/app/controllers/user_medicines_controller.rb
+++ b/app/controllers/user_medicines_controller.rb
@@ -25,11 +25,11 @@ class UserMedicinesController < ApplicationController
   end
 
   def add_stock
-    @user_medicine = current_user.user_medicines.find(params[:id])
+    @user_medicine = current_user.user_medicines.find_by(uuid: params[:id])
   end
 
   def update_stock
-    @user_medicine = current_user.user_medicines.find(params[:id])
+    @user_medicine = current_user.user_medicines.find_by(uuid: params[:id])
 
     # 元の在庫量を保存
     original_stock = @user_medicine.current_stock

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,12 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  validates :uuid, presence: true, uniqueness: true
+
   has_many :user_medicines, dependent: :destroy
+
+  # URLでuuidを使用するための設定
+  def to_param
+    uuid
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  validates :uuid, presence: true, uniqueness: true
+  validates :uuid, uniqueness: true
 
   has_many :user_medicines, dependent: :destroy
 

--- a/app/models/user_medicine.rb
+++ b/app/models/user_medicine.rb
@@ -11,7 +11,7 @@ class UserMedicine < ApplicationRecord
 
   validate :date_of_prescription_cannot_be_in_future
 
-  validates :uuid, presence: true, uniqueness: true
+  validates :uuid, uniqueness: true
 
   # いつもの薬リストに表示する薬を取得
   scope :regular_medicines, -> { where(is_regular: true) }

--- a/app/models/user_medicine.rb
+++ b/app/models/user_medicine.rb
@@ -11,6 +11,8 @@ class UserMedicine < ApplicationRecord
 
   validate :date_of_prescription_cannot_be_in_future
 
+  validates :uuid, presence: true, uniqueness: true
+
   # いつもの薬リストに表示する薬を取得
   scope :regular_medicines, -> { where(is_regular: true) }
 
@@ -36,6 +38,10 @@ class UserMedicine < ApplicationRecord
     [ prescribed_amount - consumed, 0 ].max
   end
 end
+
+  def to_param
+    uuid
+  end
 
 private
 

--- a/app/models/user_medicine.rb
+++ b/app/models/user_medicine.rb
@@ -37,16 +37,16 @@ class UserMedicine < ApplicationRecord
     consumed = days_passed * dosage_per_time
     [ prescribed_amount - consumed, 0 ].max
   end
-end
 
   def to_param
     uuid
   end
 
-private
+  private
 
-def date_of_prescription_cannot_be_in_future
-  if date_of_prescription.present? && date_of_prescription > Date.current
-    errors.add(:date_of_prescription, "は今日以前の日付を指定してください")
+  def date_of_prescription_cannot_be_in_future
+    if date_of_prescription.present? && date_of_prescription > Date.current
+      errors.add(:date_of_prescription, "は今日以前の日付を指定してください")
+    end
   end
 end

--- a/db/migrate/20260109031421_add_uuid_to_users.rb
+++ b/db/migrate/20260109031421_add_uuid_to_users.rb
@@ -1,0 +1,7 @@
+class AddUuidToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :uuid, :uuid, default: 'gen_random_uuid()', null: false
+
+    add_index :users, :uuid, unique: true
+  end
+end

--- a/db/migrate/20260109031434_add_uuid_to_user_medicines.rb
+++ b/db/migrate/20260109031434_add_uuid_to_user_medicines.rb
@@ -1,0 +1,7 @@
+class AddUuidToUserMedicines < ActiveRecord::Migration[7.2]
+  def change
+    add_column :user_medicines, :uuid, :uuid, default: 'gen_random_uuid()', null: false
+
+    add_index :user_medicines, :uuid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_18_093608) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_09_031434) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,7 +24,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_18_093608) do
     t.boolean "is_regular", default: true
     t.string "medicine_name", null: false
     t.integer "dosage_per_time", null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.index ["user_id"], name: "index_user_medicines_on_user_id"
+    t.index ["uuid"], name: "index_user_medicines_on_uuid", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -36,8 +38,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_18_093608) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uuid"], name: "index_users_on_uuid", unique: true
   end
 
   add_foreign_key "user_medicines", "users"


### PR DESCRIPTION
### 概要

issue [#110]
URLに表示される連番のidを隠すために、UsersテーブルとUserMedicinesテーブルにuuidカラムを追加してidの代わりにuuidを表示させる実装をしました。

### 作業内容

1. UsersテーブルとUserMedicinesテーブルにuuidカラムとindexを追加するマイグレーションファイルを作成

2. db: migrateを実行

3. models/user.rbとuser_medicine.rb
- uuidを呼び出すto_paramを定義
- `uniqueness: true`のバリデーションを定義

4.  user_medicines_controller.rb #add_stock, update_stock
 - uuidカラムで探す記述

### 機能追加理由

URLに連番のidが剥き出しだとユーザーが情報を推察できてしまうため、uuidで隠しました。

### 備考

Railsではidを主キーとした前提の設計が多いので、uuidを主キーにはしませんでした。
APIを使う予定はないため、外部から情報が漏れないと考えて外部キー制約もidのまま行いました。