### PR TITLE
【Bugfix】GithubActionsを使って本番環境で在庫が自動で減る実装に変更する

### DIFF
--- a/.github/workflows/consume_medicine_task.yml
+++ b/.github/workflows/consume_medicine_task.yml
@@ -5,10 +5,10 @@ on:
     # 毎日 UTC 15:00 = 日本時間 0:00 に実行
     - cron: '0 15 * * *'
   workflow_dispatch: # 手動実行も可能にする
-  push:
-    branches:
-      - bugfix/cron_for_render  # 現在の作業ブランチ
-      - main  # main ブランチでも動作確認
+  # push:
+  #   branches:
+  #     - bugfix/cron_for_render  # 現在の作業ブランチ
+  #     - main  # main ブランチでも動作確認
 
 jobs:
   run-task:

--- a/.github/workflows/consume_medicine_task.yml
+++ b/.github/workflows/consume_medicine_task.yml
@@ -1,0 +1,29 @@
+name: Consume Medicine Task
+
+on:
+  schedule:
+    # 毎日 UTC 15:00 = 日本時間 0:00 に実行
+    - cron: '0 15 * * *'
+  workflow_dispatch: # 手動実行も可能にする
+
+jobs:
+  run-task:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3.10
+          bundler-cache: true
+
+      - name: Run Run medicine reduce stock task
+        env:
+          RAILS_ENV: production
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+        run: |
+          bundle exec rails medicine_stock:reduce_medicine_stock

--- a/.github/workflows/consume_medicine_task.yml
+++ b/.github/workflows/consume_medicine_task.yml
@@ -5,6 +5,10 @@ on:
     # 毎日 UTC 15:00 = 日本時間 0:00 に実行
     - cron: '0 15 * * *'
   workflow_dispatch: # 手動実行も可能にする
+  push:
+    branches:
+      - bugfix/cron_for_render  # 現在の作業ブランチ
+      - main  # main ブランチでも動作確認
 
 jobs:
   run-task:

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM base AS build
 
 # Install packages needed to build gems and node modules
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git libpq-dev libyaml-dev node-gyp pkg-config python-is-python3 cron && \
+    apt-get install --no-install-recommends -y build-essential git libpq-dev libyaml-dev node-gyp pkg-config python-is-python3 && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install JavaScript dependencies
@@ -65,11 +65,6 @@ RUN rm -rf node_modules
 # Final stage for app image
 FROM base
 
-# cronをインストール（
-RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y cron && \
-    rm -rf /var/lib/apt/lists /var/cache/apt/archives
-
 # Copy built artifacts: gems, application
 COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
 COPY --from=build /okan /okan
@@ -80,9 +75,8 @@ RUN groupadd --system --gid 1000 rails && \
     chown -R rails:rails db log storage tmp
 USER 1000:1000
 
-# docker-entrypointに実行権限を付与
-RUN chmod +x /okan/bin/docker-entrypoint
-ENTRYPOINT ["/okan/bin/docker-entrypoint"]
+# Entrypoint prepares the database.
+ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3000


### PR DESCRIPTION
### 概要

issue[#125]
GithubActionsを使って本番環境の薬の在庫量を自動で減らす処理を定期実行する。

### 作業内容
- Dockerfileのcron関連の記述を削除
- .github/workflows/consume_medicine_task.ymlを作成
- GitHub SecretsにDBとマスターキーの環境変数を登録
- 現在の作業ブランチにpush


### 確認事項
- GithubリポジトリのActionsタブのConsume Medicine Taskを選択し、ログを確認

### 備考
確認用に開発用ブランチでpushしたらActionsタブのConsume Medicine Taskが表示されるために、consume_medicine_task.ymlに明示的に記述する必要がありました。確認後はコメントアウトしました。
