### PR TITLE
【Feature】UserとUserMedicineのモデルスペックを記述

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  validates :name, presence: true, length: { maximum: 20 }
   validates :uuid, uniqueness: true
 
   has_many :user_medicines, dependent: :destroy

--- a/app/models/user_medicine.rb
+++ b/app/models/user_medicine.rb
@@ -2,23 +2,17 @@ class UserMedicine < ApplicationRecord
   belongs_to :user
 
   validates :medicine_name, presence: true
-
   validates :dosage_per_time, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_blank: true }
-
   validates :prescribed_amount, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_blank: true }
-
   # validates :current_stock, numericality: { greater_than_or_equal_to: 0 }
-
+  validates :date_of_prescription, presence: true
   validate :date_of_prescription_cannot_be_in_future
-
   validates :uuid, uniqueness: true
 
   # いつもの薬リストに表示する薬を取得
   scope :regular_medicines, -> { where(is_regular: true) }
-
   # 単発の薬を取得(本リリースで使用予定)
   scope :temporary_medicines, -> { where(is_regular: false) }
-
   scope :with_current_stock, -> { where("current_stock > 0").order(created_at: :asc) }
 
   # カレンダーの日付を押した時の予想在庫数計算

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,8 @@
 ja:
   activerecord:
     attributes:
+      user:
+        name: "名前"
       user_medicine:
         medicine_name: "薬名"
         dosage_per_time: "1回の服薬量"

--- a/spec/models/user_medicine_spec.rb
+++ b/spec/models/user_medicine_spec.rb
@@ -1,5 +1,155 @@
 require 'rails_helper'
 
 RSpec.describe UserMedicine, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーションチェック' do
+    let(:user) { create(:user) }
+
+    it '設定したすべてのバリデーションが機能しているか' do
+      user_medicine = build(:user_medicine, user: user)
+      expect(user_medicine).to be_valid
+      expect(user_medicine.errors).to be_empty
+    end
+
+    describe 'medicine_name' do
+      it 'medicine_nameがない場合にバリデーションが機能してinvalidになるか' do
+        user_medicine = build(:user_medicine, user: user, medicine_name: nil)
+        expect(user_medicine).to be_invalid
+        expect(user_medicine.errors[:medicine_name]).to include("を入力してください")
+      end
+
+      it 'medicine_nameが空文字の場合にバリデーションが機能してinvalidになるか' do
+        user_medicine = build(:user_medicine, user: user, medicine_name: "")
+        expect(user_medicine).to be_invalid
+        expect(user_medicine.errors[:medicine_name]).to include("を入力してください")
+      end
+    end
+
+    describe 'dosage_per_time' do
+      it 'dosage_per_timeがない場合にバリデーションが機能してinvalidになるか' do
+        user_medicine = build(:user_medicine, user: user, dosage_per_time: nil)
+        expect(user_medicine).to be_invalid
+        expect(user_medicine.errors[:dosage_per_time]).to include("を入力してください")
+      end
+
+      it 'dosage_per_timeが整数でない場合にバリデーションが機能してinvalidになるか' do
+        user_medicine = build(:user_medicine, user: user, dosage_per_time: 1.5)
+        expect(user_medicine).to be_invalid
+        expect(user_medicine.errors[:dosage_per_time]).to include("は整数で入力してください")
+      end
+
+      it 'dosage_per_timeが0の場合にバリデーションが機能してinvalidになるか' do
+        user_medicine = build(:user_medicine, user: user, dosage_per_time: 0)
+        expect(user_medicine).to be_invalid
+        expect(user_medicine.errors[:dosage_per_time]).to include("は1以上の値にしてください")
+      end
+
+      it 'dosage_per_timeが負の数の場合にバリデーションが機能してinvalidになるか' do
+        user_medicine = build(:user_medicine, user: user, dosage_per_time: -1)
+        expect(user_medicine).to be_invalid
+        expect(user_medicine.errors[:dosage_per_time]).to include("は1以上の値にしてください")
+      end
+
+      it 'dosage_per_timeが1の場合にvalidになるか' do
+        user_medicine = build(:user_medicine, user: user, dosage_per_time: 1)
+        expect(user_medicine).to be_valid
+      end
+    end
+
+    describe 'prescribed_amount' do
+      it 'prescribed_amountがない場合にバリデーションが機能してinvalidになるか' do
+        user_medicine = build(:user_medicine, user: user, prescribed_amount: nil)
+        expect(user_medicine).to be_invalid
+        expect(user_medicine.errors[:prescribed_amount]).to include("を入力してください")
+      end
+
+      it 'prescribed_amountが整数でない場合にバリデーションが機能してinvalidになるか' do
+        user_medicine = build(:user_medicine, user: user, prescribed_amount: 10.5)
+        expect(user_medicine).to be_invalid
+        expect(user_medicine.errors[:prescribed_amount]).to include("は整数で入力してください")
+      end
+
+      it 'prescribed_amountが0の場合にバリデーションが機能してinvalidになるか' do
+        user_medicine = build(:user_medicine, user: user, prescribed_amount: 0)
+        expect(user_medicine).to be_invalid
+        expect(user_medicine.errors[:prescribed_amount]).to include("は1以上の値にしてください")
+      end
+
+      it 'prescribed_amountが負の数の場合にバリデーションが機能してinvalidになるか' do
+        user_medicine = build(:user_medicine, user: user, prescribed_amount: -10)
+        expect(user_medicine).to be_invalid
+        expect(user_medicine.errors[:prescribed_amount]).to include("は1以上の値にしてください")
+      end
+
+      it 'prescribed_amountが1の場合にvalidになるか' do
+        user_medicine = build(:user_medicine, user: user, prescribed_amount: 1)
+        expect(user_medicine).to be_valid
+      end
+    end
+
+    describe 'uuid' do
+      it 'uuidが被った場合にuniqueのバリデーションが機能してinvalidになるか' do
+        uuid = SecureRandom.uuid
+        create(:user_medicine, user: user, uuid: uuid)
+        user_medicine = build(:user_medicine, user: user, uuid: uuid)
+        expect(user_medicine).to be_invalid
+        expect(user_medicine.errors[:uuid]).to include("はすでに存在します")
+      end
+
+      it 'uuidが被らない場合はvalidになるか' do
+        create(:user_medicine, user: user)
+        user_medicine = build(:user_medicine, user: user)
+        expect(user_medicine).to be_valid
+      end
+    end
+
+    describe 'date_of_prescription' do
+      it 'date_of_prescriptionがない場合にバリデーションが機能してinvalidになるか' do
+        user_medicine = build(:user_medicine, user: user, date_of_prescription: nil)
+        expect(user_medicine).to be_invalid
+        expect(user_medicine.errors[:date_of_prescription]).to be_present
+      end
+
+      it 'date_of_prescriptionが未来日の場合にカスタムバリデーションが機能してinvalidになるか' do
+        user_medicine = build(:user_medicine, user: user, date_of_prescription: Date.tomorrow)
+        expect(user_medicine).to be_invalid
+        expect(user_medicine.errors[:date_of_prescription]).to be_present
+      end
+
+      it 'date_of_prescriptionが今日の日付の場合にvalidになるか' do
+        user_medicine = build(:user_medicine, user: user, date_of_prescription: Date.today)
+        expect(user_medicine).to be_valid
+      end
+
+      it 'date_of_prescriptionが過去の日付の場合にvalidになるか' do
+        user_medicine = build(:user_medicine, user: user, date_of_prescription: Date.yesterday)
+        expect(user_medicine).to be_valid
+      end
+    end
+  end
+
+  describe 'カラムのデフォルト値' do
+    let(:user) { create(:user) }
+
+    it 'current_stockのデフォルト値が0であること' do
+      user_medicine = UserMedicine.new(user: user)
+      expect(user_medicine.current_stock).to eq(0)
+    end
+
+    it 'is_regularのデフォルト値がtrueであること' do
+      user_medicine = UserMedicine.new(user: user)
+      expect(user_medicine.is_regular).to eq(true)
+    end
+
+    it 'uuidが自動生成されること' do
+      user_medicine = create(:user_medicine, user: user)
+      expect(user_medicine.uuid).to be_present
+    end
+  end
+
+  describe 'アソシエーション' do
+    it 'userに属していること' do
+      association = described_class.reflect_on_association(:user)
+      expect(association.macro).to eq(:belongs_to)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,48 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーションチェック' do
+    it '設定したすべてのバリデーションが機能しているか' do
+      user = build(:user)
+      expect(user).to be_valid
+      expect(user.errors).to be_empty
+    end
+
+    it 'nameがない場合にバリデーションが機能してinvalidになるか' do
+      user = build(:user, name: nil)
+      expect(user).to be_invalid
+      expect(user.errors[:name]).to include("を入力してください")
+    end
+
+    it 'emailがない場合にバリデーションが機能してinvalidになるか' do
+      user = build(:user, email: nil)
+      expect(user).to be_invalid
+      expect(user.errors[:email]).to include("を入力してください")
+    end
+
+    it 'passwordがない場合にバリデーションが機能してinvalidになるか' do
+      user = build(:user, password: nil, password_confirmation: nil)
+      expect(user).to be_invalid
+      expect(user.errors[:password]).to include("を入力してください")
+    end
+
+    it 'emailが被った場合にuniqueのバリデーションが機能してinvalidになるか' do
+      user1 = create(:user, email: "test@example.com")
+      user2 = build(:user, email: "test@example.com")
+      expect(user2).to be_invalid
+      expect(user2.errors[:email]).to include("はすでに存在します")
+    end
+
+    it 'emailが被らない場合はvalidになるか' do
+      user1 = create(:user, email: "test1@example.com")
+      user2 = build(:user, email: "test2@example.com")
+      expect(user2).to be_valid
+    end
+
+    it 'uuidが自動生成されること' do
+      user = create(:user)
+      expect(user.uuid).to be_present
+      expect(user.uuid).to match(/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe User, type: :model do
     it 'uuidが自動生成されること' do
       user = create(:user)
       expect(user.uuid).to be_present
-      expect(user.uuid).to match(/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/)
     end
   end
 end


### PR DESCRIPTION
### 概要

issue [#69]
UserとUserMedicineのモデルスペックを記述し、Rspecが通ることを確認しました。

### 作業内容

- spec/models/user.rbとuser_medicine.rbにテストを記述

**テストを書いていく中で修正した箇所**
- models/user.rb
nameカラムにpresence: trueを追加

- mdoels/user_medicine.rb
dosage_per_timeカラムにpresence: trueを追加


### 機能追加理由

テストを書くことで手動では気づかないエラーなどを確認し、品質を上げるために書きました。

### 備考
issueではFactoryBotの記述を行うと書いていましたが、issue[#68]にて実装済みのため本issueでは行いません。