### PR TITLE
【Change】ログイン後のトップページを変更

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,6 @@
+class HomeController < ApplicationController
+  def index
+    @medicines_with_stock = current_user.user_medicines.with_current_stock
+    @date = params[:date]&.to_date
+  end
+end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,7 +2,7 @@ class StaticPagesController < ApplicationController
   skip_before_action :authenticate_user!, only: [ :top ]
   def top
     if user_signed_in?
-      redirect_to user_medicines_path
+      redirect_to home_path
     end
   end
 end

--- a/app/controllers/user_medicines_controller.rb
+++ b/app/controllers/user_medicines_controller.rb
@@ -1,12 +1,13 @@
 class UserMedicinesController < ApplicationController
   def index
+    @user_medicine = current_user.user_medicines
     @medicines_with_stock = current_user.user_medicines.with_current_stock
     @date = params[:date]&.to_date
   end
 
   # 薬選択画面
   def select_medicine
-    @medicines_with_stock = current_user.user_medicines.with_current_stock
+    @user_medicine = current_user.user_medicines
   end
 
   def new

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,0 +1,2 @@
+module HomeHelper
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,54 @@
+<div class="container mx-auto px-4 py-8">
+  <!-- 服薬中の薬一覧 -->
+  <div class="medicines-section max-w-4xl mx-auto mb-8">
+    <!-- 今日の日付を表示 -->
+    <h2 class="text-2xl font-bold text-center mb-6">
+      <%= l(Date.today, format: :long) %>
+    </h2>
+
+    <% if @medicines_with_stock.any? %>
+      <table class="table w-full bg-white shadow-md rounded-lg overflow-hidden">
+        <tbody>
+          <% @medicines_with_stock.each do |user_medicine| %>
+            <tr class="border-b">
+              <td class="px-6 py-4"><%= user_medicine.medicine_name %></td>
+              <td class="px-6 py-4 text-right">残り<%= user_medicine.current_stock %>錠</td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p class="text-center text-gray-500 py-8">現在、薬はありません。</p>
+    <% end %>
+  </div>
+
+  <!-- カレンダー表示 -->
+  <div class="calendar-section max-w-4xl mx-auto mb-8">
+    <%= month_calendar do |date| %>
+      <%= link_to date.day,
+        user_medicines_path(date: date),
+        data: { turbo_frame: "stock_modal" } %>
+
+      <!-- カレンダー上の残り10錠表示 -->
+      <% @medicines_with_stock.each do |medicine| %>
+        <% stock = medicine.stock_on(date) %>
+        <% if stock == 10 %>
+          <span class="block text-xs text-error">
+            <%= medicine.medicine_name %>：残り10錠
+          </span>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="actions text-center">
+    <%= link_to "薬の追加", select_medicine_user_medicines_path, class: "btn btn-primary" %>
+  </div>
+
+  <!-- モーダル枠 -->
+  <turbo-frame id="stock_modal">
+    <% if params[:date].present? %>
+      <%= render "stock_modal" %>
+    <% end %>
+  </turbo-frame>
+</div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -3,6 +3,33 @@
   <div class="drawer-content">
 
     <!-- Body -->
+
+    <h1>手元の薬の在庫を管理できるお薬管理アプリです</h1>
+
+    <h3>アプリの説明
+    <br>
+    .
+    <br>
+    .
+     <br>
+    .
+     <br>
+    .
+     <br>
+    .
+     <br>
+    .
+     <br>
+    .
+     <br>
+    .
+     <br>
+    .
+     <br>
+    .
+    <br>
+    .
+    </h3>
     <main class="flex flex-col items-center justify-center mt-40 px-6 space-y-5">
       <%= link_to "新規登録", new_user_registration_path,
           class: "btn btn-primary w-full max-w-xs" %>

--- a/app/views/user_medicines/index.html.erb
+++ b/app/views/user_medicines/index.html.erb
@@ -1,54 +1,13 @@
-<div class="container mx-auto px-4 py-8">
-  <!-- 服薬中の薬一覧 -->
-  <div class="medicines-section max-w-4xl mx-auto mb-8">
-    <!-- 今日の日付を表示 -->
-    <h2 class="text-2xl font-bold text-center mb-6">
-      <%= l(Date.today, format: :long) %>
-    </h2>
-
-    <% if @medicines_with_stock.any? %>
-      <table class="table w-full bg-white shadow-md rounded-lg overflow-hidden">
-        <tbody>
-          <% @medicines_with_stock.each do |user_medicine| %>
-            <tr class="border-b">
-              <td class="px-6 py-4"><%= user_medicine.medicine_name %></td>
-              <td class="px-6 py-4 text-right">残り<%= user_medicine.current_stock %>錠</td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    <% else %>
-      <p class="text-center text-gray-500 py-8">現在、薬はありません。</p>
+<div class="bg-white rounded-lg shadow mb-6">
+    <% @user_medicine.each do |user_medicine| %>
+      <div class="flex items-center justify-between p-4 border-b hover:bg-gray-50 mb-4">
+        <div>
+          <h3 class="font-semibold text-lg"><%= user_medicine.medicine_name %></h3>
+          <p class="text-gray-600">1回の服薬量: <%= user_medicine.dosage_per_time %>錠</p>
+        </div>
+        <%= link_to "選択",
+            add_stock_user_medicine_path(user_medicine),
+            class: "px-4 py-2 btn btn-primary" %>
+      </div>
     <% end %>
   </div>
-
-  <!-- カレンダー表示 -->
-  <div class="calendar-section max-w-4xl mx-auto mb-8">
-    <%= month_calendar do |date| %>
-      <%= link_to date.day,
-        user_medicines_path(date: date),
-        data: { turbo_frame: "stock_modal" } %>
-
-      <!-- カレンダー上の残り10錠表示 -->
-      <% @medicines_with_stock.each do |medicine| %>
-        <% stock = medicine.stock_on(date) %>
-        <% if stock == 10 %>
-          <span class="block text-xs text-error">
-            <%= medicine.medicine_name %>：残り10錠
-          </span>
-        <% end %>
-      <% end %>
-    <% end %>
-  </div>
-
-  <div class="actions text-center">
-    <%= link_to "薬の追加", select_medicine_user_medicines_path, class: "btn btn-primary" %>
-  </div>
-
-  <!-- モーダル枠 -->
-  <turbo-frame id="stock_modal">
-    <% if params[:date].present? %>
-      <%= render "stock_modal" %>
-    <% end %>
-  </turbo-frame>
-</div>

--- a/app/views/user_medicines/index.html.erb
+++ b/app/views/user_medicines/index.html.erb
@@ -1,13 +1,17 @@
 <div class="bg-white rounded-lg shadow mb-6">
+  <%if @user_medicine.any? %>
     <% @user_medicine.each do |user_medicine| %>
       <div class="flex items-center justify-between p-4 border-b hover:bg-gray-50 mb-4">
         <div>
           <h3 class="font-semibold text-lg"><%= user_medicine.medicine_name %></h3>
-          <p class="text-gray-600">1回の服薬量: <%= user_medicine.dosage_per_time %>錠</p>
+          <p class="text-gray-600">1回の服薬量：<%= user_medicine.dosage_per_time %>錠</p>
         </div>
         <%= link_to "選択",
             add_stock_user_medicine_path(user_medicine),
             class: "px-4 py-2 btn btn-primary" %>
       </div>
     <% end %>
-  </div>
+  <% else %>
+    <p class="text-center py-8">現在、薬はありません</p>
+  <% end %>
+</div>

--- a/app/views/user_medicines/select_medicine.html.erb
+++ b/app/views/user_medicines/select_medicine.html.erb
@@ -1,7 +1,7 @@
 <div class="container mx-auto px-4 py-8">
   <h1 class="font-bold text-4xl text-center mb-6">薬選択画面</h1>
   <div class="bg-white rounded-lg shadow mb-6">
-    <% @medicines_with_stock.each do |user_medicine| %>
+    <% @user_medicine.each do |user_medicine| %>
       <div class="flex items-center justify-between p-4 border-b hover:bg-gray-50 mb-4">
         <div>
           <h3 class="font-semibold text-lg"><%= user_medicine.medicine_name %></h3>

--- a/app/views/user_medicines/select_medicine.html.erb
+++ b/app/views/user_medicines/select_medicine.html.erb
@@ -5,7 +5,7 @@
       <div class="flex items-center justify-between p-4 border-b hover:bg-gray-50 mb-4">
         <div>
           <h3 class="font-semibold text-lg"><%= user_medicine.medicine_name %></h3>
-          <p class="text-gray-600">1回の服薬量: <%= user_medicine.dosage_per_time %>錠</p>
+          <p class="text-gray-600">1回の服薬量：<%= user_medicine.dosage_per_time %>錠</p>
         </div>
         <%= link_to "選択",
             add_stock_user_medicine_path(user_medicine),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,4 +21,5 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "static_pages#top"
+  get "home", to: "home#index"
 end

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the HomeHelper. For example:
+#
+# describe HomeHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe HomeHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,6 +73,7 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include FactoryBot::Syntax::Methods
+  config.include Devise::Test::IntegrationHelpers, type: :system
   config.include LoginMacros
   config.before(:each, type: :system) do
     driven_by :remote_chrome

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Homes", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/system/user_medicines_spec.rb
+++ b/spec/system/user_medicines_spec.rb
@@ -13,4 +13,73 @@ RSpec.describe "UserMedicines", type: :system do
       end
     end
   end
+
+  describe 'ログイン後' do
+    before do
+      sign_in user
+    end
+
+    describe '薬の一覧表示' do
+      context '薬が登録されていない場合' do
+        it '「現在、薬はありません」というメッセージが表示される' do
+          visit user_medicines_path
+          expect(page).to have_content '現在、薬はありません'
+        end
+      end
+
+      context '薬が登録されている場合' do
+        let!(:user_medicine) { create(:user_medicine, user: user, medicine_name: 'aaa', current_stock: 5, dosage_per_time: 1) }
+
+        it '登録した薬が表示される' do
+          visit user_medicines_path
+          expect(page).to have_content 'aaa'
+          expect(page).to have_content '1回の服薬量：1錠'
+          expect(page).to have_content '選択'
+        end
+      end
+    end
+
+    describe '薬選択画面表示' do
+      context '登録が登録されている場合' do
+        let!(:user_medicine) { create(:user_medicine, user: user, medicine_name: 'aaa', current_stock: 5, dosage_per_time: 1) }
+
+        it '登録した薬が表示される' do
+          visit select_medicine_user_medicines_path
+          expect(page).to have_content 'aaa'
+          expect(page).to have_content '1回の服薬量：1錠'
+          expect(page).to have_content '選択'
+          expect(page).to have_content '新規登録'
+        end
+      end
+    end
+
+    describe '薬の新規登録' do
+      context 'フォームの入力値が正常' do
+        it '薬の新規作成が成功する' do
+          visit new_user_medicine_path
+          fill_in '薬名', with: 'aaa'
+          fill_in '1回の服薬量', with: '1'
+          fill_in '処方量', with: '30'
+          fill_in '処方日', with: Date.current
+          click_button '薬を追加'
+          expect(page).to have_content '薬を登録しました'
+          expect(current_path).to eq user_medicines_path
+        end
+      end
+    end
+
+    describe '薬の在庫追加' do
+      let!(:user_medicine) { create(:user_medicine, user: user, medicine_name: '風邪薬', current_stock: 5, dosage_per_time: 1) }
+      context 'フォームの入力値が正常' do
+        it '薬の在庫追加が成功する' do
+          visit add_stock_user_medicine_path(user_medicine)
+          fill_in '処方量', with: '30'
+          fill_in '処方日', with: Date.current
+          click_button '在庫を追加'
+          expect(page).to have_content '薬を追加しました'
+          expect(current_path).to eq user_medicines_path
+        end
+      end
+    end
+  end
 end

--- a/spec/system/user_medicines_spec.rb
+++ b/spec/system/user_medicines_spec.rb
@@ -50,6 +50,13 @@ RSpec.describe "UserMedicines", type: :system do
           expect(page).to have_content '選択'
           expect(page).to have_content '新規登録'
         end
+
+        it '選択ボタンを押すと薬名、1回の服薬量、現在の在庫が表示されている' do
+          visit add_stock_user_medicine_path(user_medicine)
+          expect(page).to have_content 'aaa'
+          expect(page).to have_content '1 錠'
+          expect(page).to have_content '5 錠'
+        end
       end
     end
 


### PR DESCRIPTION
### 概要

issue [#128]
ログイン後のトップページをhome#indexに変更しました。ログイン前は変更せずにstatic_pages#topのままにしました。
ログイン後のuser_medicinesのシステムスペックを記述しました。

### 作業内容

**トップページのリンク編集関連**
- home_controller.rbを作成
変数を定義

- home/index.html.erb
服薬中の薬一覧とカレンダーを表示する記述

- config/routes.rb
home#indexのルーティングを記述

- static_pages/top.html.erb
ログイン済みならhome#indexに遷移する記述

- user_medicines/index.html.erb
薬の一覧だけを表示する記述

**Rspec関連**

- spec/rails_helper.rb
システムスペックでdeviseのログインができる設定を記述

- system/user_medicine.rb
ログイン後の薬の一覧、選択画面、新規作成、在庫追加のテストを記述

### 機能追加理由

登録した薬の一覧を表示する機能をuser_medicines#indexで実装するために、現在のカレンダー表示をhome#indexで表示することで機能とファイルの名前を分けました。

### 備考

ログイン前はstatic_pages#topでアプリの説明をしてからログインと新規作成ボタンから遷移できるほうがユーザーフレンドリーだと考えて実装しませんでした。