### PR TITLE
【Feature】薬詳細表示の実装

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -16,7 +16,7 @@
   --color-secondary-content: #FFFFFF;
   --color-accent: #F4B79F; /* アイコン、リンク、タグなど細かい装飾 */
   --color-accent-content: oklch(98% 0.01 160);
-  --color-neutral: #3D3A38;
+  --color-neutral: #C0C0C0;
   --color-neutral-content: oklch(98% 0.01 240);
   --color-info: #66A6FF; /* お知らせ */
   --color-info-content: oklch(98% 0.01 220);

--- a/app/controllers/user_medicines_controller.rb
+++ b/app/controllers/user_medicines_controller.rb
@@ -5,6 +5,10 @@ class UserMedicinesController < ApplicationController
     @date = params[:date]&.to_date
   end
 
+  def show
+    @user_medicine = current_user.user_medicines.find_by(uuid: params[:id])
+  end
+
   # 薬選択画面
   def select_medicine
     @user_medicine = current_user.user_medicines

--- a/app/views/user_medicines/index.html.erb
+++ b/app/views/user_medicines/index.html.erb
@@ -6,8 +6,8 @@
           <h3 class="font-semibold text-lg"><%= user_medicine.medicine_name %></h3>
           <p class="text-gray-600">1回の服薬量：<%= user_medicine.dosage_per_time %>錠</p>
         </div>
-        <%= link_to "選択",
-            add_stock_user_medicine_path(user_medicine),
+        <%= link_to "詳細",
+            user_medicine_path(user_medicine),
             class: "px-4 py-2 btn btn-primary" %>
       </div>
     <% end %>

--- a/app/views/user_medicines/show.html.erb
+++ b/app/views/user_medicines/show.html.erb
@@ -1,0 +1,57 @@
+<div class="container mx-auto px-4 py-8">
+  <div class="medicines-section max-w-4xl mx-auto mb-8">
+    <div class="md:w-2/3 w-full">
+
+      <div class="bg-white rounded-lg shadow p-6">
+        <div class="mb-4">
+          <label class="block text-sm font-bold mb-2">薬名</label>
+          <div class="bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-700">
+            <%= @user_medicine.medicine_name %>
+          </div>
+        </div>
+
+        <div class="mb-4">
+          <label class="block text-sm font-bold mb-2">1回の服薬量</label>
+          <div class="bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-700">
+            <%= @user_medicine.dosage_per_time %> 錠
+          </div>
+        </div>
+
+        <div class="mb-4">
+          <label class="block text-sm font-bold mb-2">現在の在庫</label>
+          <div class="bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-700 ">
+            <%= @user_medicine.current_stock %> 錠
+          </div>
+        </div>
+
+        <div class="mb-4">
+          <label class="block text-sm font-bold mb-2">処方量</label>
+          <div class="bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-700 ">
+            <%= @user_medicine.prescribed_amount %> 錠
+          </div>
+        </div>
+
+        <div class="mb-4">
+          <label class="block text-sm font-bold mb-2">最新の処方日</label>
+          <div class="bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-700 ">
+            <%= @user_medicine.date_of_prescription %>
+          </div>
+        </div>
+
+        <div class="space-y-4">
+          <div class="flex gap-4">
+            <%= link_to "在庫を追加", add_stock_user_medicine_path(@user_medicine), class: "btn btn-primary flex-1" %>
+            <%= link_to "飲み忘れ", "#", class: "btn btn-secondary flex-1" %>
+          </div>
+
+          <div class="flex gap-4">
+            <%= link_to "編集", "#", class: "btn btn-outline btn-sm flex-1" %>
+            <%= link_to "削除", "#", class: "btn btn-error btn-sm flex-1" %>
+            <%= link_to "戻る", user_medicines_path, class: "btn btn-neutral btn-sm flex-1" %>
+          </div>
+        </div>
+       </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/spec/system/user_medicines_spec.rb
+++ b/spec/system/user_medicines_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "UserMedicines", type: :system do
           visit user_medicines_path
           expect(page).to have_content 'aaa'
           expect(page).to have_content '1回の服薬量：1錠'
-          expect(page).to have_content '選択'
+          expect(page).to have_content '詳細'
         end
       end
     end
@@ -86,6 +86,21 @@ RSpec.describe "UserMedicines", type: :system do
           expect(page).to have_content '薬を追加しました'
           expect(current_path).to eq user_medicines_path
         end
+      end
+    end
+
+    describe '薬の詳細表示' do
+      let(:user_medicine) { create(:user_medicine, user: user) }
+      before do
+        user_medicine
+        visit user_medicine_path(user_medicine)
+      end
+
+      it '登録した全ての項目が表示されること' do
+        expect(page).to have_content(user_medicine.medicine_name)
+        expect(page).to have_content(user_medicine.dosage_per_time)
+        expect(page).to have_content(user_medicine.prescribed_amount)
+        expect(page).to have_content(user_medicine.date_of_prescription)
       end
     end
   end


### PR DESCRIPTION
### 概要

issue [#67]
選択した薬の詳細情報が表示されるページを作成しました。
在庫追加、飲み忘れ、編集、削除、戻るのボタンを設置しました。

### 作業内容

**機能実装**
- user_medicine#showを記述
- user_medicine/show.html.erbを記述

**テスト**
- system/user_medicine.rb
選択した薬の詳細情報が表示されることを確認するテストを記述

### 機能追加理由
登録した薬の詳細情報を確認することができるようにしました。また、各種ボタンを設置することでその薬に対して行いたいことがすぐできる動線を作りました。

### 備考
在庫追加と戻るボタンはリンク先を記述していますが、そのほかは未実装のためまだリンクは仮のものにしています。