### PR TITLE
【bugfix】予想薬在庫数のモーダルを表示

### DIFF
--- a/app/controllers/user_medicines_controller.rb
+++ b/app/controllers/user_medicines_controller.rb
@@ -1,8 +1,6 @@
 class UserMedicinesController < ApplicationController
   def index
     @user_medicine = current_user.user_medicines
-    @medicines_with_stock = current_user.user_medicines.with_current_stock
-    @date = params[:date]&.to_date
   end
 
   def show

--- a/app/views/home/_stock_modal.html.erb
+++ b/app/views/home/_stock_modal.html.erb
@@ -22,7 +22,7 @@
 
     <div class="modal-action">
       <%= link_to "閉じる",
-            user_medicines_path,
+            home_path,
             class: "btn" %>
     </div>
   </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -26,7 +26,7 @@
   <div class="calendar-section max-w-4xl mx-auto mb-8">
     <%= month_calendar do |date| %>
       <%= link_to date.day,
-        user_medicines_path(date: date),
+        home_path(date: date),
         data: { turbo_frame: "stock_modal" } %>
 
       <!-- カレンダー上の残り10錠表示 -->


### PR DESCRIPTION
### 概要

[#136]
カレンダーの日付を押して、その日の予想在庫数がモーダルに表示されるように修正しました。

### 作業内容

- _stock_modal.html.erb
  - user_medicinesディレクトリからhomeディレクトリに移動
  - 閉じるを押した後のリンク先をhome_pathに修正
  
- home/index.html.erb
リンクが飛ぶ先をhome_pathに修正

- user_medicines_controller.rb #index
必要のなくなったmedicines_with_stock、date変数を削除

### 確認事項

カレンダーの日付を押して、その日の予想在庫数がモーダルに表示されるようになりました。
