### PR TITLE
【Feature】ユーザーのログアウト機能を実装

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4 # ファイルをGitHub Actions上に保存
-        if: always()
+        if: failure()
         with:
           name: screenshots
           path: tmp/capybara

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="min-h-screen flex items-center justify-center bg-base-100">
+<div class="flex items-center justify-center bg-base-100 mb-20">
   <div class="card w-11/12 max-w-sm bg-base-200 shadow-lg rounded-xl p-6">
     <h2 class="text-center text-2xl font-bold text-primary mb-6">ユーザー設定</h2>
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
@@ -8,7 +8,7 @@
         <%= f.text_field :name, class: "input input-bordered bg-white" %>
         <% if resource.errors[:name].any? %>
           <% resource.errors[:name]&.full_messages do |message| %>
-            <p class="text-red-600 text-xs mt-1 ml-1"><%= t('.name') %><%= message %></p>
+            <p class="text-red-600 text-xs mt-1 ml-1"><%= t(".name") %><%= message %></p>
           <% end %>
         <% end %>
       </div>
@@ -18,7 +18,7 @@
         <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered bg-white" %>
         <% if resource.errors[:email].any? %>
           <% resource.errors[:email]&.each do |message| %>
-            <p class="text-red-600 text-xs mt-1 ml-1"><%= t('.email') %><%= message %></p>
+            <p class="text-red-600 text-xs mt-1 ml-1"><%= t(".email") %><%= message %></p>
           <% end %>
         <% end %>
       </div>
@@ -35,7 +35,7 @@
         <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered bg-white" %>
         <% if resource.errors[:password].any? %>
           <% resource.errors[:password]&.each do |message| %>
-            <p class="text-red-600 text-xs mt-1 ml-1"><%= t('devise.registrations.new.password') %><%= message %></p>
+            <p class="text-red-600 text-xs mt-1 ml-1"><%= t("devise.registrations.new.password") %><%= message %></p>
           <% end %>
         <% end %>
       </div>
@@ -45,7 +45,7 @@
         <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input input-bordered bg-white" %>
         <% if resource.errors[:password_confirmation].any? %>
           <% resource.errors[:password_confirmation]&.each do |message| %>
-            <p class="text-red-600 text-xs mt-1 ml-1"><%= t('.password_confirmation') %><%= message %></p>
+            <p class="text-red-600 text-xs mt-1 ml-1"><%= t(".password_confirmation") %><%= message %></p>
           <% end %>
         <% end %>
       </div>
@@ -56,7 +56,7 @@
         <%= f.password_field :current_password, autocomplete: "current-password", class: "input input-bordered bg-white" %>
         <% if resource.errors[:current_password].any? %>
           <% resource.errors[:current_password]&.each do |message| %>
-            <p class="text-red-600 text-xs mt-1 ml-1"><%= t('.current_password') %><%= message %></p>
+            <p class="text-red-600 text-xs mt-1 ml-1"><%= t(".current_password") %><%= message %></p>
           <% end %>
         <% end %>
       </div>
@@ -66,10 +66,14 @@
         <%= link_to "戻る", home_path, class: "btn btn-neutral flex-1" %>
       </div>
     <% end %>
-    <div class="text-center gap-4 mt-10">
-      <%= button_to "アカウント削除", registration_path(resource_name), data: { confirm: t('.cancel_confirmation'), turbo_confirm: t('.cancel_confirmation') }, method: :delete, class: "btn btn-error text-black" %>
+
+    <div class="text-center">
+      <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "btn bg-white text-[#E56A54] border border-[#E56A54] hover:bg-[#FFE4DF] w-full max-w-xs mt-10" %>
     </div>
-    <br>
+
+    <div class="text-center">
+      <%= link_to "アカウント削除", registration_path(resource_name), data: { turbo_method: :delete, confirm: t(".cancel_confirmation"), turbo_confirm: t(".cancel_confirmation") }, class: "btn btn-error text-black mt-8 mb-8" %>
+    </div>
   </div>
 </div>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="flex items-center justify-center bg-base-100 mb-20">
   <div class="card w-11/12 max-w-sm bg-base-200 shadow-lg rounded-xl p-6">
-    <h2 class="text-center text-2xl font-bold text-primary mb-6">ユーザー設定</h2>
+    <h2 class="text-center text-2xl font-bold text-primary mb-6">アカウント設定</h2>
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
 
       <div class="form-control mb-4">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -68,7 +68,7 @@
     <% end %>
 
     <div class="text-center">
-      <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "btn bg-white text-[#E56A54] border border-[#E56A54] hover:bg-[#FFE4DF] w-full max-w-xs mt-10" %>
+      <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete, confirm: t(".logout_confirmation"), turbo_confirm: t(".logout_confirmation") }, class: "btn bg-white text-[#E56A54] border border-[#E56A54] hover:bg-[#FFE4DF] w-full max-w-xs mt-10" %>
     </div>
 
     <div class="text-center">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div class="min-h-screen flex items-center justify-center bg-base-100">
+<div class="flex items-center justify-center bg-base-100">
   <div class="card w-11/12 max-w-sm bg-base-200 shadow-lg rounded-xl p-6">
     <h2 class="text-center text-2xl font-bold text-primary mb-6">ログイン</h2>
 

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -51,6 +51,7 @@ ja:
         password: "パスワード"
         password_confirmation: "パスワード（確認用）"
         current_password: "現在のパスワード"
+        logout_confirmation: "ログアウトしますか？"
         cancel_confirmation: 'アカウントを本当に削除しますか？'
     sessions:
       signed_in: 'ログインしました。'

--- a/spec/system/users/edit_registrations_spec.rb
+++ b/spec/system/users/edit_registrations_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'UserEditRegistrations', type: :system do
     it 'アカウント削除が成功する', js: true do
         # 確認ダイアログを自動的にOKにする
         accept_confirm do
-        click_button 'アカウント削除'
+          click_link 'アカウント削除'
         end
 
         expect(page).to have_content('アカウントを削除しました。またのご利用をお待ちしております。')
@@ -90,7 +90,7 @@ RSpec.describe 'UserEditRegistrations', type: :system do
         deleted_password = 'password'
 
         accept_confirm do
-        click_button 'アカウント削除'
+        click_link 'アカウント削除'
         end
 
         # 削除されたユーザーでログインを試みる

--- a/spec/system/users/sessions_spec.rb
+++ b/spec/system/users/sessions_spec.rb
@@ -15,4 +15,20 @@ RSpec.describe 'UserSessions', type: :system do
       end
     end
   end
+  describe 'ログイン後' do
+    before do
+      login_as(user)
+      # 画面サイズを広げる
+      page.driver.browser.manage.window.resize_to(1200, 1000)
+    end
+
+    context 'ログアウトボタンをクリック' do
+      it 'ログアウト処理が成功する' do
+        visit edit_user_registration_path
+        click_link 'ログアウト'
+        expect(page).to have_content('ログアウトしました。')
+        expect(current_path).to eq root_path
+      end
+    end
+  end
 end

--- a/spec/system/users/sessions_spec.rb
+++ b/spec/system/users/sessions_spec.rb
@@ -25,7 +25,11 @@ RSpec.describe 'UserSessions', type: :system do
     context 'ログアウトボタンをクリック' do
       it 'ログアウト処理が成功する' do
         visit edit_user_registration_path
-        click_link 'ログアウト'
+
+        accept_confirm do
+          click_link 'ログアウト'
+        end
+
         expect(page).to have_content('ログアウトしました。')
         expect(current_path).to eq root_path
       end


### PR DESCRIPTION
### 概要

issue [#75]
ユーザーがログアウトする機能を実装しました。

### 作業内容

**機能追加**
- registrations/edit.html.erb
  - ログアウトボタンを設置
  - フラッシュメッセージで「ログアウトしますか？」を表示
 
- config/locales/devise.ja.yml
「ログアウトしますか？」の翻訳を記述

**修正**
- registrations/edit.html.erb
アカウント削除ボタンを画面下部へ移動し、`button_to`から`link_to`へ変更

- devise/sessions/new.html.erb
スマホサイズで見やすいように要素を上部へ移動

**テスト関連**

- spec/system/users/sessions_spec.rb
ログアウト機能のテストを記述

- spec/system/edit_registrations_spec.rb
削除ボタンをクリックする記述を`button_click`から`link_click`に変更

### 機能追加理由

フラッシュメッセージで確認を踏ませることによって誤操作によるログアウトを防ぎました。

### 備考

ハンバーガーメニューにはログアウトを直接設置せずに、アカウントのリンクからログアウトできることによって動線を減らしました。
また、フラッシュメッセージはJavascriptではなくturboで実装しました。