### PR TITLE
【Feature】Medicineテーブルの作成

### DIFF
--- a/app/controllers/user_medicines_controller.rb
+++ b/app/controllers/user_medicines_controller.rb
@@ -21,18 +21,19 @@ class UserMedicinesController < ApplicationController
   end
 
   def new
-    @user_medicine = UserMedicine.new
+    @form = UserMedicineForm.new
   end
 
   def create
-    @user_medicine = current_user.user_medicines.build(user_medicine_params)
-    @user_medicine.current_stock = @user_medicine.initial_stock_on_create
+    @form = UserMedicineForm.new(
+      user_medicine_form_params.merge(user: current_user)
+    )
 
-      if @user_medicine.save
-        redirect_to user_medicines_path, notice: "薬を登録しました"
-      else
-        render :new, status: :unprocessable_entity
-      end
+    if @form.save
+      redirect_to user_medicines_path, notice: "薬を登録しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
   end
 
   def add_stock
@@ -45,7 +46,7 @@ class UserMedicinesController < ApplicationController
     # 元の在庫量を保存
     original_stock = @user_medicine.current_stock
 
-    # フォームから送信された値をモデルに代入
+    # フォームから送信された値をモデルに代入(空で入力するとバリデーションエラーに引っ掛けるため)
     @user_medicine.assign_attributes(user_medicine_params)
 
     # バリデーションチェック
@@ -68,10 +69,17 @@ class UserMedicinesController < ApplicationController
 
   private
 
-  def user_medicine_params
-    params.require(:user_medicine).permit(
+  def user_medicine_form_params
+    params.require(:user_medicine_form).permit(
       :medicine_name,
       :dosage_per_time,
+      :prescribed_amount,
+      :date_of_prescription
+    )
+  end
+
+  def user_medicine_params
+    params.require(:user_medicine).permit(
       :prescribed_amount,
       :date_of_prescription
     )

--- a/app/controllers/user_medicines_controller.rb
+++ b/app/controllers/user_medicines_controller.rb
@@ -7,10 +7,10 @@ class UserMedicinesController < ApplicationController
     query = params[:query]
 
     # 自分が過去に入力した薬名のみを取得
-    suggestions = current_user.user_medicines
-                               .where("medicine_name LIKE ?", "#{query}%")
+    suggestions = current_user.medicines
+                               .where("name LIKE ?", "#{query}%")
                                .distinct
-                               .pluck(:medicine_name)
+                               .pluck(:name)
                                .first(10)
     # 配列をJSON形式に変換してブラウザに返す
     render json: suggestions

--- a/app/forms/user_medicine_form.rb
+++ b/app/forms/user_medicine_form.rb
@@ -1,0 +1,71 @@
+class UserMedicineForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :medicine_name, :string
+  attribute :dosage_per_time, :integer
+  attribute :prescribed_amount, :integer
+  attribute :date_of_prescription, :date
+
+  validates :medicine_name, presence: true
+  validates :dosage_per_time, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_blank: true }
+  validates :prescribed_amount, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_blank: true }
+  validates :date_of_prescription, presence: true
+  validate :date_of_prescription_cannot_be_in_future
+  validate :medicine_not_duplicated
+
+  def initialize(attributes = {})
+    # attributesハッシュから:userキーを取り出して削除(userはフォームオブジェクトの属性ではないため)
+    @user = attributes.delete(:user)
+    super(attributes)
+  end
+
+  def save
+    # フォームオブジェクトに設定したバリデーションを実行
+    return false unless valid?
+
+    ActiveRecord::Base.transaction do
+      medicine = @user.medicines.find_or_create_by!(name: medicine_name)
+
+      user_medicine = @user.user_medicines.build(
+        medicine: medicine,
+        dosage_per_time: dosage_per_time,
+        prescribed_amount: prescribed_amount,
+        date_of_prescription: date_of_prescription
+      )
+
+      user_medicine.current_stock = user_medicine.initial_stock_on_create
+
+      unless user_medicine.save
+        # モデルのエラーをフォームオブジェクトに転記
+        user_medicine.errors.each do |error|
+          errors.add(error.attribute, error.message)
+        end
+        raise ActiveRecord::Rollback
+      end
+
+      @user_medicine = user_medicine
+      true
+    end
+  rescue ActiveRecord::RecordInvalid => e
+    errors.add(:base, e.message)
+    false
+  end
+
+  private
+
+  def date_of_prescription_cannot_be_in_future
+    if date_of_prescription.present? && date_of_prescription > Date.today
+      errors.add(:date_of_prescription, "は未来の日付にできません")
+    end
+  end
+
+  def medicine_not_duplicated
+    return if medicine_name.blank? || @user.nil?
+
+    medicine = Medicine.find_by(name: medicine_name)
+    if medicine && @user.user_medicines.exists?(medicine: medicine)
+      errors.add(:medicine_name, "は既に登録されています")
+    end
+  end
+end

--- a/app/models/medicine.rb
+++ b/app/models/medicine.rb
@@ -1,0 +1,7 @@
+class Medicine < ApplicationRecord
+  belongs_to :user
+  # Medicineは一つのUserMedicineを持つ
+  has_one :user_medicine, dependent: :destroy
+
+  validates :name, presence: true, uniqueness: { scope: :user_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   validates :uuid, uniqueness: true
 
   has_many :user_medicines, dependent: :destroy
+  has_many :medicines, dependent: :destroy
 
   # URLでuuidを使用するための設定
   def to_param

--- a/app/models/user_medicine.rb
+++ b/app/models/user_medicine.rb
@@ -1,7 +1,9 @@
 class UserMedicine < ApplicationRecord
   belongs_to :user
+  # UserMedicineはMedicineに属している
+  belongs_to :medicine
 
-  validates :medicine_name, presence: true
+  validates :medicine_id, uniqueness: { scope: :user_id }
   validates :dosage_per_time, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_blank: true }
   validates :prescribed_amount, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_blank: true }
   # validates :current_stock, numericality: { greater_than_or_equal_to: 0 }

--- a/app/models/user_medicine.rb
+++ b/app/models/user_medicine.rb
@@ -11,10 +11,6 @@ class UserMedicine < ApplicationRecord
   validate :date_of_prescription_cannot_be_in_future
   validates :uuid, uniqueness: true
 
-  # いつもの薬リストに表示する薬を取得
-  scope :regular_medicines, -> { where(is_regular: true) }
-  # 単発の薬を取得(本リリースで使用予定)
-  scope :temporary_medicines, -> { where(is_regular: false) }
   scope :with_current_stock, -> { where("current_stock > 0").order(created_at: :asc) }
 
   # カレンダーの日付を押した時の予想在庫数計算

--- a/app/views/home/_stock_modal.html.erb
+++ b/app/views/home/_stock_modal.html.erb
@@ -10,7 +10,7 @@
     <% elsif @medicines_with_stock.any? %>
       <% @medicines_with_stock.each do |medicine| %>
         <p>
-          <%= medicine.medicine_name %>：
+          <%= medicine.medicine.name %>：
           残り<%= medicine.stock_on(@date) %> 錠
         </p>
       <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -11,7 +11,7 @@
         <tbody>
           <% @medicines_with_stock.each do |user_medicine| %>
             <tr class="border-b">
-              <td class="px-6 py-4"><%= user_medicine.medicine_name %></td>
+              <td class="px-6 py-4"><%= user_medicine.medicine.name %></td>
               <td class="px-6 py-4 text-right">残り<%= user_medicine.current_stock %>錠</td>
             </tr>
           <% end %>
@@ -34,7 +34,7 @@
         <% stock = medicine.stock_on(date) %>
         <% if stock == 10 %>
           <span class="block text-xs text-error">
-            <%= medicine.medicine_name %>：残り10錠
+            <%= medicine.medicine.name %>：残り10錠
           </span>
         <% end %>
       <% end %>

--- a/app/views/user_medicines/add_stock.html.erb
+++ b/app/views/user_medicines/add_stock.html.erb
@@ -12,7 +12,7 @@
           <div class="mb-4">
             <label class="block text-sm font-bold mb-2">薬名</label>
             <div class="bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-700">
-              <%= @user_medicine.medicine_name %>
+              <%= @user_medicine.medicine.name %>
             </div>
           </div>
 

--- a/app/views/user_medicines/index.html.erb
+++ b/app/views/user_medicines/index.html.erb
@@ -6,7 +6,7 @@
           <div class="flex items-center justify-between p-4 border-b hover:bg-gray-50 mb-4">
             <div class="flex-1">
               <div class="flex items-center gap-2">
-                <h3 class="font-semibold text-lg"><%= user_medicine.medicine_name %></h3>
+                <h3 class="font-semibold text-lg"><%= user_medicine.medicine.name %></h3>
                 <% if user_medicine.current_stock > 0 %>
                   <span class="bg-red-100 text-red-600 text-xs font-medium px-2 py-0.5 rounded">服薬中</span>
                 <% end %>

--- a/app/views/user_medicines/new.html.erb
+++ b/app/views/user_medicines/new.html.erb
@@ -7,10 +7,21 @@
         <%= form_with model: @form, url: user_medicines_path do |f| %>
           <%= render 'shared/error_messages', object: @form %>
 
-          <div class="mb-4">
+          <div class="mb-4" data-controller="autocomplete">
             <%= f.label :medicine_name, "薬名", class: "block text-sm font-bold mb-2" %>
-            <div class="flex items-center">
-              <%= f.text_field :medicine_name, class: "form-control flex-1 border border-gray-300 rounded px-3 py-2" %>
+            <div class="relative">
+            <!-- input ターゲット -->
+              <%= f.text_field :medicine_name,
+                  class: "form-control flex-1 border border-gray-300 rounded px-3 py-2 w-full",
+                  autocomplete: "off",
+                  data: {
+                    autocomplete_target: "input",
+                    action: "input->autocomplete#search"
+                  } %>
+              <!-- results ターゲット -->
+              <div data-autocomplete-target="results"
+                  class="absolute z-10 w-full bg-white border border-gray-300 rounded mt-1">
+              </div>
             </div>
           </div>
 

--- a/app/views/user_medicines/new.html.erb
+++ b/app/views/user_medicines/new.html.erb
@@ -4,13 +4,13 @@
       <h1 class="font-bold text-4xl text-center mb-6">新規登録</h1>
 
       <div class="bg-white rounded-lg shadow p-6">
-        <%= form_with(model: @user_medicine) do |f| %>
-          <%= render 'shared/error_messages', object: f.object %>
+        <%= form_with model: @form, url: user_medicines_path do |f| %>
+          <%= render 'shared/error_messages', object: @form %>
 
           <div class="mb-4">
             <%= f.label :medicine_name, "薬名", class: "block text-sm font-bold mb-2" %>
             <div class="flex items-center">
-              <%= text_field_tag :medicine_name, nil, class: "form-control flex-1 border border-gray-300 rounded px-3 py-2" %>
+              <%= f.text_field :medicine_name, class: "form-control flex-1 border border-gray-300 rounded px-3 py-2" %>
             </div>
           </div>
 

--- a/app/views/user_medicines/new.html.erb
+++ b/app/views/user_medicines/new.html.erb
@@ -7,21 +7,10 @@
         <%= form_with(model: @user_medicine) do |f| %>
           <%= render 'shared/error_messages', object: f.object %>
 
-          <div class="mb-4" data-controller="autocomplete">
+          <div class="mb-4">
             <%= f.label :medicine_name, "薬名", class: "block text-sm font-bold mb-2" %>
-            <div class="relative">
-              <!-- input ターゲット -->
-              <%= f.text_field :medicine_name,
-                  class: "flex-1 border border-gray-300 rounded px-3 py-2 w-full",
-                  autocomplete: "off",
-                  data: {
-                    autocomplete_target: "input",
-                    action: "input->autocomplete#search"
-                  } %>
-              <!-- results ターゲット -->
-              <div data-autocomplete-target="results"
-                  class="absolute z-10 w-full bg-white border border-gray-300 rounded mt-1">
-              </div>
+            <div class="flex items-center">
+              <%= text_field_tag :medicine_name, nil, class: "form-control flex-1 border border-gray-300 rounded px-3 py-2" %>
             </div>
           </div>
 

--- a/app/views/user_medicines/show.html.erb
+++ b/app/views/user_medicines/show.html.erb
@@ -6,7 +6,7 @@
         <div class="mb-4">
           <label class="block text-sm font-bold mb-2">薬名</label>
           <div class="bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-700">
-            <%= @user_medicine.medicine_name %>
+            <%= @user_medicine.medicine.name %>
           </div>
         </div>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,8 +5,9 @@ ja:
         name: "名前"
         email: "メールアドレス"
         password_confirmation: "パスワード確認"
+      medicine:
+        name: "薬名"
       user_medicine:
-        medicine_name: "薬名"
         dosage_per_time: "1回の服薬量"
         prescribed_amount: "処方量"
     errors:
@@ -15,6 +16,15 @@ ja:
           attributes:
             medicine_name:
               blank: "を入力してください"
+  activemodel:
+    models:
+      user_medicine_form: 薬の登録
+    attributes:
+      user_medicine_form:
+        medicine_name: 薬名
+        dosage_per_time: 1回の服用量
+        prescribed_amount: 処方量
+        date_of_prescription: 処方日
   date:
     formats:
       default: "%Y/%m/%d"

--- a/db/migrate/20260118232743_medicine.rb
+++ b/db/migrate/20260118232743_medicine.rb
@@ -1,0 +1,10 @@
+class Medicine < ActiveRecord::Migration[7.2]
+  def change
+    create_table :medicines do |t|
+      t.string :name, null: false
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+    end
+    add_index :medicines, [ :user_id, :name ], unique: true
+  end
+end

--- a/db/migrate/20260118235423_remove_medicine_name_from_user_medicines.rb
+++ b/db/migrate/20260118235423_remove_medicine_name_from_user_medicines.rb
@@ -1,0 +1,10 @@
+class RemoveMedicineNameFromUserMedicines < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :user_medicines, :medicine_name, :string
+    remove_column :user_medicines, :is_regular, :boolean
+
+    add_reference :user_medicines, :medicine, null: false, foreign_key: true
+
+    add_index :user_medicines, [ :user_id, :medicine_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_09_031434) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_18_235423) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "medicines", force: :cascade do |t|
+    t.string "name", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "name"], name: "index_medicines_on_user_id_and_name", unique: true
+    t.index ["user_id"], name: "index_medicines_on_user_id"
+  end
 
   create_table "user_medicines", force: :cascade do |t|
     t.integer "prescribed_amount", null: false
@@ -21,10 +30,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_09_031434) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "is_regular", default: true
-    t.string "medicine_name", null: false
     t.integer "dosage_per_time", null: false
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.bigint "medicine_id", null: false
+    t.index ["medicine_id"], name: "index_user_medicines_on_medicine_id"
+    t.index ["user_id", "medicine_id"], name: "index_user_medicines_on_user_id_and_medicine_id", unique: true
     t.index ["user_id"], name: "index_user_medicines_on_user_id"
     t.index ["uuid"], name: "index_user_medicines_on_uuid", unique: true
   end
@@ -44,5 +54,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_09_031434) do
     t.index ["uuid"], name: "index_users_on_uuid", unique: true
   end
 
+  add_foreign_key "medicines", "users"
+  add_foreign_key "user_medicines", "medicines"
   add_foreign_key "user_medicines", "users"
 end

--- a/spec/factories/medicines.rb
+++ b/spec/factories/medicines.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :medicine do
+    sequence(:name) { |n| "薬#{n}" }
+    association :user
+  end
+end

--- a/spec/factories/user_medicines.rb
+++ b/spec/factories/user_medicines.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :user_medicine do
-    sequence(:medicine_name) { |n| "薬#{n}" }
     dosage_per_time { 1 }
     prescribed_amount { 30 }
     date_of_prescription { Date.current }
-    is_regular { true }
+    sequence(:uuid) { SecureRandom.uuid }
     association :user
+    association :medicine
   end
 end

--- a/spec/forms/user_medicine_form_spec.rb
+++ b/spec/forms/user_medicine_form_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe UserMedicineForm, type: :model do
+  let(:user) { create(:user) }
+
+  describe 'バリデーション' do
+    it '全ての値が正しい場合、validになること' do
+      form = UserMedicineForm.new(
+        user: user,
+        medicine_name: '新しい薬',
+        dosage_per_time: 1,
+        prescribed_amount: 30,
+        date_of_prescription: Date.current
+      )
+      expect(form).to be_valid
+    end
+
+    it 'medicine_nameがない場合、invalidになること' do
+      form = UserMedicineForm.new(
+        user: user,
+        medicine_name: nil,
+        dosage_per_time: 1,
+        prescribed_amount: 30,
+        date_of_prescription: Date.current
+      )
+      expect(form).to be_invalid
+      expect(form.errors[:medicine_name]).to be_present
+    end
+  end
+
+  describe '薬の新規登録' do
+    context '新しい薬名の場合' do
+      it 'MedicineとUserMedicineが作成されること' do
+        form = UserMedicineForm.new(
+          user: user,
+          medicine_name: '新しい薬',
+          dosage_per_time: 1,
+          prescribed_amount: 30,
+          date_of_prescription: Date.current
+        )
+        expect { form.save }.to change(Medicine, :count).by(1)
+                            .and change(UserMedicine, :count).by(1)
+      end
+    end
+
+    context '既存の薬名の場合' do
+      let!(:existing_medicine) { create(:medicine, user: user, name: '既存の薬') }
+
+      it 'Medicineは作成されず、UserMedicineのみ作成されること' do
+        form = UserMedicineForm.new(
+          user: user,
+          medicine_name: '既存の薬',
+          dosage_per_time: 1,
+          prescribed_amount: 30,
+          date_of_prescription: Date.current
+        )
+        expect { form.save }.to change(Medicine, :count).by(0)
+                            .and change(UserMedicine, :count).by(1)
+      end
+    end
+  end
+end

--- a/spec/models/medicine_spec.rb
+++ b/spec/models/medicine_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Medicine, type: :model do
+  describe 'バリデーションチェック' do
+     let(:user) { create(:user) }
+
+    it '設定したすべてのバリデーションが機能しているか' do
+      medicine = build(:medicine, user: user)
+      expect(medicine).to be_valid
+      expect(medicine.errors).to be_empty
+    end
+
+    describe 'name' do
+      it 'nameがない場合にバリデーションが機能してinvalidになるか' do
+        medicine = build(:medicine, user: user, name: nil)
+        expect(medicine).to be_invalid
+        expect(medicine.errors[:name]).to include('を入力してください')
+      end
+
+      it 'nameが空文字の場合にバリデーションが機能してinvalidになるか' do
+        medicine = build(:medicine, user: user, name: '')
+        expect(medicine).to be_invalid
+        expect(medicine.errors[:name]).to include('を入力してください')
+      end
+    end
+  end
+end

--- a/spec/models/medicine_spec.rb
+++ b/spec/models/medicine_spec.rb
@@ -16,12 +16,6 @@ RSpec.describe Medicine, type: :model do
         expect(medicine).to be_invalid
         expect(medicine.errors[:name]).to include('を入力してください')
       end
-
-      it 'nameが空文字の場合にバリデーションが機能してinvalidになるか' do
-        medicine = build(:medicine, user: user, name: '')
-        expect(medicine).to be_invalid
-        expect(medicine.errors[:name]).to include('を入力してください')
-      end
     end
   end
 end

--- a/spec/system/user_medicines_spec.rb
+++ b/spec/system/user_medicines_spec.rb
@@ -28,11 +28,17 @@ RSpec.describe "UserMedicines", type: :system do
       end
 
       context '薬が登録されている場合' do
-        let!(:user_medicine) { create(:user_medicine, user: user, medicine_name: 'aaa', current_stock: 5, dosage_per_time: 1) }
+        let!(:medicine) { create(:medicine, name: 'テスト薬A') }
+        let!(:user_medicine) do
+         create(:user_medicine,
+                 user: user,
+                 medicine: medicine,
+                dosage_per_time: 1)
+        end
 
         it '登録した薬が表示される' do
           visit user_medicines_path
-          expect(page).to have_content 'aaa'
+          expect(page).to have_content 'テスト薬A'
           expect(page).to have_content '1回の服薬量：1錠'
           expect(page).to have_content '選択'
         end
@@ -43,19 +49,21 @@ RSpec.describe "UserMedicines", type: :system do
       context 'フォームの入力値が正常' do
         it '薬の新規作成が成功する' do
           visit new_user_medicine_path
-          fill_in '薬名', with: 'aaa'
+          fill_in '薬名', with: '新しい薬'
           fill_in '1回の服薬量', with: '1'
           fill_in '処方量', with: '30'
           fill_in '処方日', with: Date.current
           click_button '薬を追加'
           expect(page).to have_content '薬を登録しました'
           expect(current_path).to eq user_medicines_path
+          expect(page).to have_content '新しい薬'
         end
       end
     end
 
     describe '薬の在庫追加' do
-      let!(:user_medicine) { create(:user_medicine, user: user, medicine_name: '風邪薬', current_stock: 5, dosage_per_time: 1) }
+       let!(:medicine) { create(:medicine) }
+      let!(:user_medicine) { create(:user_medicine, user: user, medicine: medicine, current_stock: 5, dosage_per_time: 1) }
       context 'フォームの入力値が正常' do
         it '薬の在庫追加が成功する' do
           visit add_stock_user_medicine_path(user_medicine)
@@ -76,7 +84,7 @@ RSpec.describe "UserMedicines", type: :system do
       end
 
       it '登録した全ての項目が表示されること' do
-        expect(page).to have_content(user_medicine.medicine_name)
+        expect(page).to have_content(user_medicine.medicine.name)
         expect(page).to have_content(user_medicine.dosage_per_time)
         expect(page).to have_content(user_medicine.prescribed_amount)
         expect(page).to have_content(user_medicine.date_of_prescription)


### PR DESCRIPTION
### 概要

issue [#148]
Medicinesテーブルを作成してアソシエーションを定義し、薬新規作成画面をフォームオブジェクトで実装し、従来通りブラウザで画面が表示されるようにコードを修正しました。
フォームオブジェクトのテストを作成し、テーブルの変更に合わせてその他テストコードを修正しました。

### 作業内容

**テーブル関連**
- Medicinesテーブルを作成するマイグレーションファイルを作成
  - nameカラムを作成
  - user_idの外部キー制約を追加
  - user_idとnameの複合ユニーク制約を追加
  
- UserMedicinesテーブルを変更するマイグレーションファイルを作成
  - medicine_nameカラムを削除
  - user_idとmedicine_idの複合ユニーク制約を追
  - medicine_idの外部キー制約を追加
  
**モデル関連**
- models/user.rb
has_many :medicinesを追加

- models/medicine.rb
  - belongs_to :user、has_one :user_medicineを記述
  - user_idとnameの複合ユニーク制約を記述
 
- models/user_medicine.rb
  - belongs_to :medicineを追加
  - user_idとmedicine_idの複合ユニーク制約を記述

**ビュー**
以下のファイルの薬名の表示箇所を`user_medicine.medicine_name`から`user_medicine.medicine.name`に変更
- home/index, _stock_modal.html.erb
- user_medicines/add_stock, index, new, show.html.erb

**フォームオブジェクト**
- forms/user_medicine_form.rbを作成
- user_medicines_controller.rb #new, createを編集、privateメソッドにuser_medicine_form_paramsを定義
- user_medicines/new.html.erbにフォームオブジェクトを参照するように記述
- config/locales/ja.yml
attributesのエラーが日本語になるように翻訳を記述

**その他作業**
- UserMedicinesテーブルのis_regularカラムを使わないので削除
- models/user_medicine.rb
いつもの薬リスト用に作っていたscopeを使わないので削除

**テスト**
- spec/factories/medicines.rbを作成

- spec/factories/user_medicines.rbを編集
medicine_idとの関連付けを記述

- spec/models/medicine_spec.rbを作成
バリデーションのテストを記述

- spec/models/user_medicine_spec.rbとsystem/user_medicines_pec.rbを編集
medicine_idとの関連付けを記述

- spec/forms/user_medicine_form_spec.rb
薬新規作成のフォームオブジェクトのロジックをテストする記述


### 機能追加理由

薬新規作成時の薬名オートコンプリート機能を実装する際に、以前登録したが削除した薬名を候補に出す必要がありました。Medicinesテーブルに薬名を分けて保存することでDBに情報が残って候補を出すことができるため、Medicinesテーブルを作成しました。

フォームオブジェクトを採用した理由は、FatControllerになることを避けて責務を分離するためです。

### 確認事項

同じユーザーが同じ名前の薬を複数登録することはできない。登録済みの薬一覧から在庫を増やすか、既存の薬を削除して新しく登録することはできる。

薬新規作成時に、薬名の候補にオートコンプリートで過去に削除した薬名からも候補が出せる。
