### PR TITLE
【Test】飲み忘れ機能のテストを記述

### DIFF
--- a/app/controllers/user_medicines_controller.rb
+++ b/app/controllers/user_medicines_controller.rb
@@ -69,7 +69,7 @@ class UserMedicinesController < ApplicationController
     @user_medicine = current_user.user_medicines.find_by(uuid: params[:id])
 
     if @user_medicine.increment_stock
-      redirect_to user_medicine_path(@user_medicine), notice: "在庫を1回の服薬量分増やしました。"
+      redirect_to user_medicine_path(@user_medicine), notice: "在庫を1回分増やしました。"
     else
       render :forgot_index, status: :unprocessable_entity
     end


### PR DESCRIPTION
### 概要

issue [#72]のサブissueのPR
飲み忘れ機能のシステムスペックを記述しました。

### 作業内容

記述したテストの内容
spec/system/user_medicines_spec.rb
- 薬詳細画面の飲み忘れボタンの表示
  - 在庫があれば飲み忘れボタンが表示される
  - 在庫がなければ飲み忘れボタンは表示されない
 
- 飲み忘れボタンを押した場合
  - フラッシュメッセージではいを押したら在庫量が1回の服薬薬量分増えている
  - フラッシュメッセージでキャンセルしたら在庫量は変わらない
