### PR TITLE
【Bugfix】服薬中バッジの表示乱れを修正

### DIFF
--- a/app/forms/user_medicine_form.rb
+++ b/app/forms/user_medicine_form.rb
@@ -7,7 +7,7 @@ class UserMedicineForm
   attribute :prescribed_amount, :integer
   attribute :date_of_prescription, :date
 
-  validates :medicine_name, presence: true
+  validates :medicine_name, presence: true, length: { maximum: 20 }
   validates :dosage_per_time, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_blank: true }
   validates :prescribed_amount, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_blank: true }
   validates :date_of_prescription, presence: true

--- a/app/models/medicine.rb
+++ b/app/models/medicine.rb
@@ -3,5 +3,5 @@ class Medicine < ApplicationRecord
   # Medicineは一つのUserMedicineを持つ
   has_one :user_medicine, dependent: :destroy
 
-  validates :name, presence: true, uniqueness: { scope: :user_id }
+  validates :name, presence: true, length: { maximum: 20 }, uniqueness: { scope: :user_id }
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container mx-auto px-4 mb-8">
+<div class="container mx-auto px-4 mb-10">
   <!-- 服薬中の薬一覧 -->
   <div class="medicines-section max-w-4xl mx-auto mb-8">
     <!-- 今日の日付を表示 -->

--- a/app/views/user_medicines/index.html.erb
+++ b/app/views/user_medicines/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container mx-auto px-4">
+<div class="container mx-auto px-4 mb-10">
   <h1 class="font-bold text-4xl text-center mb-6">薬一覧</h1>
   <div class="bg-white rounded-lg shadow mb-6">
     <%if @user_medicine.any? %>
@@ -7,12 +7,12 @@
           <div class="flex-1">
             <div class="flex items-center gap-2">
               <h3 class="font-semibold text-lg"><%= user_medicine.medicine.name %></h3>
-              <% if user_medicine.current_stock > 0 %>
-                <span class="bg-red-100 text-red-600 text-xs font-medium px-2 py-0.5 rounded">服薬中</span>
-              <% end %>
             </div>
             <p class="text-gray-600">1回の服薬量：<%= user_medicine.dosage_per_time %>錠</p>
           </div>
+          <% if user_medicine.current_stock > 0 %>
+            <span class="bg-red-100 text-red-600 text-xs font-medium px-2 py-0.5 rounded mr-2">服薬中</span>
+          <% end %>
           <%= link_to "選択", user_medicine_path(user_medicine), class: "px-4 py-2 btn btn-primary" %>
         </div>
       <% end %>

--- a/app/views/user_medicines/new.html.erb
+++ b/app/views/user_medicines/new.html.erb
@@ -28,7 +28,7 @@
           <div class="mb-4">
             <%= f.label :dosage_per_time, "1回の服薬量", class: "block text-sm font-bold mb-2" %>
             <div class="flex items-center">
-              <%= f.number_field :dosage_per_time,
+              <%= f.number_field :dosage_per_time, min: 1,
                   class: "flex-1 border border-gray-300 rounded px-3 py-2" %>
               <span class="ml-2 text-gray-700">錠</span>
             </div>

--- a/spec/models/medicine_spec.rb
+++ b/spec/models/medicine_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe Medicine, type: :model do
         expect(medicine).to be_invalid
         expect(medicine.errors[:name]).to include('を入力してください')
       end
+
+      it 'nameが21文字以上の場合にバリデーションが機能してinvalidになるか' do
+        medicine = build(:medicine, user: user, name: 'a' * 21)
+        expect(medicine).to be_invalid
+        expect(medicine.errors[:name]).to include('は20文字以内で入力してください')
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe User, type: :model do
       expect(user.errors[:name]).to include('を入力してください')
     end
 
+    it 'nameが21文字以上の場合にバリデーションが機能してinvalidになるか' do
+        user = build(:user, name: 'a' * 21)
+        expect(user).to be_invalid
+        expect(user.errors[:name]).to include('は20文字以内で入力してください')
+      end
+
     it 'emailがない場合にバリデーションが機能してinvalidになるか' do
       user = build(:user, email: nil)
       expect(user).to be_invalid


### PR DESCRIPTION
### 概要

issue [#157]
薬一覧画面の服薬中のバッジが薬名の長さによって乱れることがあるので固定しました。
Medicinesテーブルのnameカラムに文字数制限のバリデーションをつけました。

### 作業内容

 **服薬中バッジの固定**
- user_medicines/index.html.erb
選択ボタンの左に固定して配置

**バリデーションの設定**
- models/medicine.rbとforms/user_medicine_form.rb
薬名は20文字以内の制限を記述

- spec/models/medicine_spec.rbにテストを追加
薬名が21文字以上の場合、バリデーションに引っかかるテストを記述

**その他作業**

- user_medicines/new.html.erb
ブラウザに表示される矢印を押して1以下を表示できないようにmin属性を追加

- spec/models/user_spec.rbにテストを追加
ユーザー名が21文字以上の場合、バリデーションに引っかかるテストを記述

### 確認事項

スマホ画面で服薬中バッジが乱れないことを確認しました。
薬新規作成で薬名に20文字以上を入力して登録しようとするとエラーが出て失敗することを確認しました。
