### PR TITLE
【Feature】カレンダーの残り9錠からカウントダウンする

### DIFF
--- a/app/models/user_medicine.rb
+++ b/app/models/user_medicine.rb
@@ -27,6 +27,21 @@ class UserMedicine < ApplicationRecord
     [ estimated, 0 ].max
   end
 
+  def display_stock_on(date)
+    return nil if date < Date.current
+
+    stock = self.stock_on(date)
+
+    if date > Date.current
+      return stock if [ 10, 5 ].include?(stock)
+    else
+      return stock if stock.between?(1, 4)
+    end
+
+    nil
+  end
+
+
   # 初回登録時、処方日と登録日が異なる場合の在庫量の計算
   def initial_stock_on_create
     return prescribed_amount if date_of_prescription == Date.current

--- a/app/models/user_medicine.rb
+++ b/app/models/user_medicine.rb
@@ -28,17 +28,22 @@ class UserMedicine < ApplicationRecord
   end
 
   def display_stock_on(date)
-    return nil if date < Date.current
-
     stock = self.stock_on(date)
 
-    if date > Date.current
-      return stock if [ 10, 5 ].include?(stock)
-    else
-      return stock if stock.between?(1, 4)
+    # 過去は表示しない
+    return nil if date < Date.current
+
+    # 今日
+    if date == Date.current && stock.between?(1, 9)
+      return stock
     end
 
-    nil
+    # 未来
+    if date >= Date.current
+      if stock == 10
+        10
+      end
+    end
   end
 
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -41,7 +41,7 @@
         <% display_stock = medicine.display_stock_on(date) %>
         <% if display_stock.present? %>
           <span class="block text-xs text-error leading-tight">
-        <%= medicine.medicine.name %><%= display_stock %>錠
+            <%= medicine.medicine.name %><%= display_stock %>錠
           </span>
         <% end %>
       <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -31,12 +31,12 @@
 
       <!-- カレンダー上の残り10錠表示 -->
       <% @medicines_with_stock.each do |medicine| %>
-       <% display_stock = medicine.display_stock_on(date) %>
-         <% if display_stock.present? %>
-           <span class="block text-xs text-error">
-             <%= medicine.medicine.name %>：残り<%= display_stock %>錠
-            </span>
-          <% end %>
+        <% display_stock = medicine.display_stock_on(date) %>
+        <% if display_stock.present? %>
+          <span class="block text-xs text-error">
+            <%= medicine.medicine.name %>：残り<%= display_stock %>錠
+          </span>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -31,12 +31,12 @@
 
       <!-- カレンダー上の残り10錠表示 -->
       <% @medicines_with_stock.each do |medicine| %>
-        <% stock = medicine.stock_on(date) %>
-        <% if stock == 10 %>
-          <span class="block text-xs text-error">
-            <%= medicine.medicine.name %>：残り10錠
-          </span>
-        <% end %>
+       <% display_stock = medicine.display_stock_on(date) %>
+         <% if display_stock.present? %>
+           <span class="block text-xs text-error">
+             <%= medicine.medicine.name %>：残り<%= display_stock %>錠
+            </span>
+          <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container mx-auto px-4 mb-10">
+<div class="container mx-auto px-4">
   <!-- 服薬中の薬一覧 -->
   <div class="medicines-section max-w-4xl mx-auto mb-8">
     <!-- 今日の日付を表示 -->
@@ -11,8 +11,13 @@
         <tbody>
           <% @medicines_with_stock.each do |user_medicine| %>
             <tr class="border-b">
-              <td class="px-6 py-4"><%= user_medicine.medicine.name %></td>
-              <td class="px-6 py-4 text-right">残り<%= user_medicine.current_stock %>錠</td>
+              <% if user_medicine.current_stock > 10%>
+                <td class="px-6 py-4 "><%= user_medicine.medicine.name %></td>
+                <td class="px-6 py-4 text-right">残り<%= user_medicine.current_stock %>錠</td>
+              <% else %>
+                <td class="px-6 py-4 text-error"><%= user_medicine.medicine.name %></td>
+                <td class="px-6 py-4 text-right text-error">残り<%= user_medicine.current_stock %>錠</td>
+              <%end%>
             </tr>
           <% end %>
         </tbody>
@@ -21,7 +26,9 @@
       <p class="text-center text-gray-500 py-8">現在、薬はありません。</p>
     <% end %>
   </div>
+</div>
 
+<div class="container mx-auto mb-10">
   <!-- カレンダー表示 -->
   <div class="calendar-section max-w-4xl mx-auto mb-8">
     <%= month_calendar do |date| %>
@@ -33,15 +40,17 @@
       <% @medicines_with_stock.each do |medicine| %>
         <% display_stock = medicine.display_stock_on(date) %>
         <% if display_stock.present? %>
-          <span class="block text-xs text-error">
-            <%= medicine.medicine.name %>：残り<%= display_stock %>錠
+          <span class="block text-xs text-error leading-tight">
+        <%= medicine.medicine.name %><%= display_stock %>錠
           </span>
         <% end %>
       <% end %>
     <% end %>
   </div>
+</div>
 
-  <div class="flex gap-4">
+
+  <div class="flex max-w-4xl mx-auto gap-4 px-4 mb-20">
     <%= link_to "薬の追加", user_medicines_path, class: "btn btn-primary flex-1" %>
     <%= link_to "飲み忘れ", forgot_index_user_medicines_path, class: "btn btn-secondary flex-1" %>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,7 @@
         <!-- フラッシュメッセージ -->
         <%= render 'shared/flash_message' %>
         <!-- 各ページの内容 -->
-        <main class="container mx-auto px-4 py-8">
+       
           <%= yield %>
         </main>
       </div>

--- a/app/views/user_medicines/forgot_index.html.erb
+++ b/app/views/user_medicines/forgot_index.html.erb
@@ -1,6 +1,6 @@
 <div class="container mx-auto px-4 py-8">
   <h1 class="font-bold text-4xl text-center mb-6">飲み忘れ</h1>
-  <div class="bg-white rounded-lg shadow mb-6">
+  <div class="bg-white max-w-4xl mx-auto rounded-lg shadow mb-6">
     <%if @medicines_with_stock.any? %>
       <% @medicines_with_stock.each do |user_medicine| %>
         <div class="flex items-center justify-between p-4 border-b hover:bg-gray-50 mb-4">

--- a/app/views/user_medicines/index.html.erb
+++ b/app/views/user_medicines/index.html.erb
@@ -1,6 +1,6 @@
-<div class="container mx-auto px-4 mb-10">
+<div class="container mx-auto px-4 mb-20">
   <h1 class="font-bold text-4xl text-center mb-6">薬一覧</h1>
-  <div class="bg-white rounded-lg shadow mb-6">
+  <div class="bg-white max-w-4xl mx-auto rounded-lg shadow mb-6">
     <%if @user_medicine.any? %>
       <% @user_medicine.each do |user_medicine| %>
         <div class="flex items-center justify-between p-4 border-b hover:bg-gray-50 mb-4">


### PR DESCRIPTION
### 概要

issue [#161]
薬が残り9錠以下になったら今日の日付に残り⚪︎錠と表示しました。ホーム画面の服薬中の薬の残りが10錠以下の場合は赤文字で表示しました。表示しました。


### 作業内容
**カレンダー上の残り表示**
- models/user_medicine.rb
ビューに渡す残り⚪︎錠の数字を計算するロジックを記述し、display_stock_on(date)メソッドに定義

- views/home/index.html.erb
  - display_stock_on(date)を表示する記述
  - 服薬中の薬の残りが10錠以下で赤色にする記述

**レイアウト調整**

カレンダーをスマホの端いっぱいに広げるためにいくつかのファイルを修正しました。

- views/layouts/application.html.erb
bodyの全ページに適応させるデフォルトのレイアウトを削除

- パソコンサイズの場合のリスト表示の横幅を広げ過ぎないように`max-w-4xl mx-auto`を追加
  - user_medicines/forgot_index.html.erb
  - user_medicines/index.html.erb
  - home/index.html.erbの画面下のボタン

### 機能追加理由

残りが少なくなったら今日の日付に表示されると分かりやすいため、実装しました。

### 備考

残り10錠の日が過ぎたら「残り10錠」は消して「残り5錠」を表示し、4錠以下は今日の日付に「残り⚪︎錠」と表示させる予定でしたが、とりあえずは9錠以下は今日の日付に「残り⚪︎錠」と表示させる実装にしました。

