### PR TITLE
【bugfix】本番環境でGoogleログインが成功するように修正

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -17,6 +17,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def failure
     # 認証失敗時
-    redirect_to root_path
+    redirect_to root_path, alert: "Google認証に失敗しました"
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -298,8 +298,10 @@ Devise.setup do |config|
 
   unless Rails.env.test?
     config.omniauth :google_oauth2,
-                 Rails.application.credentials.google[:google_client_id],
-                 Rails.application.credentials.google[:google_client_secret]
+      Rails.application.credentials.dig(:google, :google_client_id),
+      Rails.application.credentials.dig(:google, :google_client_secret),
+      scope: "email,profile,openid",
+      name: :google_oauth2
   end
 
   # ==> Hotwire/Turbo configuration


### PR DESCRIPTION
### 概要

issue [#77]のsub-issue
本番環境でGoogleログインができないため修正しました。
 config/initializers/devise.rbの書き方を変更してscopeを追加しました。

### 作業内容
- config/initializers/devise.rb
  - google_client_idとgoogle_client_secretをハッシュからdigメソッドを使った書き方に変更
  - 
- users/omniauth_callbacks_controller.rb
認証に失敗した時のフラッシュメッセージを記述

