### PR TITLE
【Feature】HospitalsテーブルとHospitalSchedulesテーブルを作成

### DIFF
--- a/app/controllers/hospital_controller.rb
+++ b/app/controllers/hospital_controller.rb
@@ -1,0 +1,5 @@
+class HospitalController < ApplicationController
+  def index
+    @hospital = current_user.hospitals
+  end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -10,7 +10,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in_and_redirect @user, event: :authentication
       set_flash_message(:notice, :success, kind: "#{ provider }") if is_navigational_format?
     else
-      binding.pry
       session["devise.#{ provider }_data"] = request.env["omniauth.auth"].except(:extra)
       redirect_to new_user_registration_url, alert: @user.errors.full_messages.join("\n")
     end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -10,8 +10,9 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in_and_redirect @user, event: :authentication
       set_flash_message(:notice, :success, kind: "#{ provider }") if is_navigational_format?
     else
+      binding.pry
       session["devise.#{ provider }_data"] = request.env["omniauth.auth"].except(:extra)
-      redirect_to new_user_registration_url
+      redirect_to new_user_registration_url, alert: @user.errors.full_messages.join("\n")
     end
   end
 

--- a/app/helpers/hospital_helper.rb
+++ b/app/helpers/hospital_helper.rb
@@ -1,0 +1,2 @@
+module HospitalHelper
+end

--- a/app/helpers/leftover_medicines_helper.rb
+++ b/app/helpers/leftover_medicines_helper.rb
@@ -1,2 +1,0 @@
-module LeftoverMedicinesHelper
-end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,2 +1,0 @@
-module PostsHelper
-end

--- a/app/helpers/registered_medicines_helper.rb
+++ b/app/helpers/registered_medicines_helper.rb
@@ -1,2 +1,0 @@
-module RegisteredMedicinesHelper
-end

--- a/app/models/hospital.rb
+++ b/app/models/hospital.rb
@@ -3,6 +3,6 @@ class Hospital < ApplicationRecord
   has_one :hospital_schedule, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 20 }
-  validates :description, length: { maximum: 50 }
+  validates :description, length: { maximum: 100 }
   validates :uuid, uniqueness: true
 end

--- a/app/models/hospital.rb
+++ b/app/models/hospital.rb
@@ -1,0 +1,8 @@
+class Hospital < ApplicationRecord
+  belongs_to :user
+  has_one :hospital_schedule, dependent: :destroy
+
+  validates :name, presence: true, length: { maximum: 20 }
+  validates :description, length: { maximum: 50 }
+  validates :uuid, uniqueness: true
+end

--- a/app/models/hospital_schedule.rb
+++ b/app/models/hospital_schedule.rb
@@ -1,0 +1,9 @@
+class HospitalSchedule < ApplicationRecord
+  belongs_to :hospital
+
+  enum day_of_week: { monday: 0, tuesday: 1, wednesday: 2, thursday: 3, friday: 4, saturday: 5, sunday: 6, holiday: 7 }
+  enum period: { morning: 0, afternoon: 1 }
+
+  validates :day_of_week, presence: true
+  validates :period, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
 
   has_many :user_medicines, dependent: :destroy
   has_many :medicines, dependent: :destroy
+  has_many :hospitals, dependent: :destroy
 
   # URLでuuidを使用するための設定
   def to_param

--- a/app/views/hospital/index.html.erb
+++ b/app/views/hospital/index.html.erb
@@ -1,0 +1,22 @@
+<div class="container mx-auto px-4 mb-20">
+  <h1 class="font-bold text-4xl text-center mb-6">病院一覧</h1>
+  <div class="bg-white max-w-4xl mx-auto rounded-lg shadow mb-6">
+    <%if @hospital.any? %>
+      <% @hospital.each do |hospital| %>
+        <div class="flex items-center justify-between p-4 border-b hover:bg-gray-50 mb-4">
+          <div class="flex-1">
+            <div class="flex items-center gap-2">
+              <h3 class="font-semibold text-lg"><%= hospital.name %></h3>
+            </div>
+          <%= link_to "選択", "#", class: "px-4 py-2 btn btn-primary" %>
+        </div>
+      <% end %>
+    <% else %>
+      <p class="text-center py-8">現在、病院情報はありません</p>
+    <% end %>
+   </div>
+
+  <div class="actions text-center">
+    <%= link_to "新規登録", "#", class: "btn bg-white text-[#E56A54] border border-[#E56A54] w-full max-w-xs" %>
+  </div>
+</div>

--- a/app/views/shared/_drawer_menu.html.erb
+++ b/app/views/shared/_drawer_menu.html.erb
@@ -2,6 +2,7 @@
   <label for="drawer-menu" class="drawer-overlay"></label>
     <ul class="menu p-4 w-80 bg-base-100">
       <li><%= link_to "薬一覧", user_medicines_path %></li>
+      <li><%= link_to "病院一覧", hospital_index_path %></li>
       <li><%= link_to "アカウント", edit_user_registration_path %></li>
     </ul>
 </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -24,7 +24,7 @@
     <% end %>
 
     <!-- 病院一覧 -->
-    <%= link_to '#', class: 'flex flex-col items-center gap-1 flex-1' do %>
+    <%= link_to hospital_index_path, class: 'flex flex-col items-center gap-1 flex-1' do %>
       <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="_x32_" x="0px" y="0px" width="512px" height="512px" viewBox="0 0 512 512" style="width: 32px; height: 32px; opacity: 1;" xml:space="preserve">
         <style type="text/css">
 	    .st0{fill:#4B4B4B;}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :user_medicines do
+  resources :user_medicines, only: %i[index show new create destroy] do
     collection do
       get :autocomplete
       get :forgot_index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :hospital, only: %i[index]
+
   devise_for :users, controllers: {
     registrations: "users/registrations",
     omniauth_callbacks: "users/omniauth_callbacks"

--- a/db/migrate/20260125234043_create_hospitals.rb
+++ b/db/migrate/20260125234043_create_hospitals.rb
@@ -1,0 +1,13 @@
+class CreateHospitals < ActiveRecord::Migration[7.2]
+  def change
+    create_table :hospitals do |t|
+      t.string :name, null: false
+      t.text :description
+      t.uuid :uuid, default: 'gen_random_uuid()', null: false
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+    end
+
+    add_index :hospitals, :uuid, unique: true
+  end
+end

--- a/db/migrate/20260126003922_create_hospital_schedules.rb
+++ b/db/migrate/20260126003922_create_hospital_schedules.rb
@@ -1,0 +1,12 @@
+class CreateHospitalSchedules < ActiveRecord::Migration[7.2]
+  def change
+    create_table :hospital_schedules do |t|
+      t.integer :day_of_week, null: false
+      t.integer :period, null: false
+      t.time :start_time
+      t.time :end_time
+      t.references :hospital, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,31 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_23_000248) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_26_003922) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "hospital_schedules", force: :cascade do |t|
+    t.integer "day_of_week", null: false
+    t.integer "period", null: false
+    t.time "start_time"
+    t.time "end_time"
+    t.bigint "hospital_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["hospital_id"], name: "index_hospital_schedules_on_hospital_id"
+  end
+
+  create_table "hospitals", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_hospitals_on_user_id"
+    t.index ["uuid"], name: "index_hospitals_on_uuid", unique: true
+  end
 
   create_table "medicines", force: :cascade do |t|
     t.string "name", null: false
@@ -56,6 +78,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_23_000248) do
     t.index ["uuid"], name: "index_users_on_uuid", unique: true
   end
 
+  add_foreign_key "hospital_schedules", "hospitals"
+  add_foreign_key "hospitals", "users"
   add_foreign_key "medicines", "users"
   add_foreign_key "user_medicines", "medicines"
   add_foreign_key "user_medicines", "users"

--- a/spec/factories/hospital_schedules.rb
+++ b/spec/factories/hospital_schedules.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :hospital_schedule do
+  end
+end

--- a/spec/factories/hospitals.rb
+++ b/spec/factories/hospitals.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :hospital do
+  end
+end

--- a/spec/helpers/hospital_helper_spec.rb
+++ b/spec/helpers/hospital_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the HospitalHelper. For example:
+#
+# describe HospitalHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe HospitalHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/hospital_schedule_spec.rb
+++ b/spec/models/hospital_schedule_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe HospitalSchedule, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/hospital_spec.rb
+++ b/spec/models/hospital_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Hospital, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/hospital_spec.rb
+++ b/spec/requests/hospital_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Hospitals", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
### 概要

issue [#78]
HospitalsテーブルとHospitalSchedulesテーブルを作成し、modelファイルにバリエーション、enum、アソシエーションを定義しました。
病院情報の一覧画面のルーティング、コントローラー、ビューを作成しました。

### 作業内容

1. Hospitalsテーブル、HospitalSchedulesテーブルを作成
2. HospitalsとHospitalSchedulesにアソシエーション、バリデーション、enumを定義
  - UsersとHospitalsは1対多
  - HospitalsとHospitalSchedulesは1対1
  3. 病院情報一覧の表示
  - hospital_controller.rbのindexを作成
  - ルーティングの作成
  - hospital/index.html.erbを作成
  - ハンバーガーメニューとフッターにリンクを設置


**その他作業**
- 以前作成していて、仕様変更により使わなくなったファイルを削除
  - app/helpers/leftover_medicines_helper.rb
  - app/helpers/posts_helper.rb
  - app/helpers/registered_medicines_helper.rb

- Googleログイン失敗時のフラッシュメッセージを記述

- user_medicinesのルーティングにeditとupdateがないので作成されないように記述を変更

### 機能追加理由

病院の診察時間を登録することができ、検索したり診察券を確認することなく、アプリで薬と一緒に確認できることで手間を省けるようにするために作りました。
