### PR TITLE
【Feature】病院情報一覧画面作成、一覧と作成のテストを記述

### DIFF
--- a/app/views/hospital/index.html.erb
+++ b/app/views/hospital/index.html.erb
@@ -7,7 +7,7 @@
           <div class="flex items-center gap-2">
             <h3 class="font-semibold text-lg"><%= hospital.name %></h3>
           </div>
-          <%= link_to "選択", hospital_path(hospital), class: "px-4 py-2 btn btn-primary" %>
+          <%= link_to "詳細", hospital_path(hospital), class: "px-4 py-2 btn btn-primary" %>
         </div>
       <% end %>
     <% else %>

--- a/spec/factories/hospital_schedules.rb
+++ b/spec/factories/hospital_schedules.rb
@@ -1,4 +1,9 @@
 FactoryBot.define do
   factory :hospital_schedule do
+    association :hospital
+    day_of_week { :monday }
+    period { :morning }
+    start_time { '09:00' }
+    end_time { '12:00' }
   end
 end

--- a/spec/factories/hospitals.rb
+++ b/spec/factories/hospitals.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :hospital do
     association :user
-    name { '病院A' }
-    description { '30分前から受付開始' }
+    sequence(:name) { |n| "病院#{n}" }
+    sequence(:description) { |n| "メモ#{n}" }
     uuid { SecureRandom.uuid }
   end
 end

--- a/spec/factories/hospitals.rb
+++ b/spec/factories/hospitals.rb
@@ -1,4 +1,8 @@
 FactoryBot.define do
   factory :hospital do
+    association :user
+    name { '病院A' }
+    description { '30分前から受付開始' }
+    uuid { SecureRandom.uuid }
   end
 end

--- a/spec/models/hospital_schedule_spec.rb
+++ b/spec/models/hospital_schedule_spec.rb
@@ -1,5 +1,79 @@
 require 'rails_helper'
 
 RSpec.describe HospitalSchedule, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:hospital) { create(:hospital) }
+
+  describe 'バリデーションチェック' do
+    it '設定したすべてのバリデーションが機能しているか' do
+      hospital_schedule = build(:hospital_schedule, hospital: hospital)
+      expect(hospital_schedule).to be_valid
+      expect(hospital_schedule.errors).to be_empty
+    end
+  end
+
+    describe 'day_of_week' do
+      it 'day_of_weekがない場合にバリデーションが機能してinvalidになるか' do
+        hospital_schedule = build(:hospital_schedule, hospital: hospital, day_of_week: nil)
+        expect(hospital_schedule).to be_invalid
+      end
+    end
+
+    describe 'period' do
+      it 'periodがない場合にバリデーションが機能してinvalidになるか' do
+        hospital_schedule = build(:hospital_schedule, hospital: hospital, period: nil)
+        expect(hospital_schedule).to be_invalid
+      end
+    end
+
+    describe '時間のバリデーション' do
+      it '開始時間のみ入力された場合にバリデーションが機能してinvalidになるか' do
+        hospital_schedule = build(:hospital_schedule, hospital: hospital, start_time: '09:00', end_time: nil)
+        expect(hospital_schedule).to be_invalid
+        expect(hospital_schedule.errors[:end_time]).to include('を入力してください')
+      end
+
+      it '終了時間のみ入力された場合にバリデーションが機能してinvalidになるか' do
+        hospital_schedule = build(:hospital_schedule, hospital: hospital, start_time: nil, end_time: '12:00')
+        expect(hospital_schedule).to be_invalid
+        expect(hospital_schedule.errors[:start_time]).to include('を入力してください')
+      end
+
+      it '開始時間が終了時間より後の場合にバリデーションが機能してinvalidになるか' do
+        hospital_schedule = build(:hospital_schedule, hospital: hospital, start_time: '12:00', end_time: '09:00')
+        expect(hospital_schedule).to be_invalid
+        expect(hospital_schedule.errors[:end_time]).to include('は開始時間より遅い時刻に設定してください')
+      end
+
+      it '開始時間と終了時間が正しい場合にバリデーションが通るか' do
+        hospital_schedule = build(:hospital_schedule, hospital: hospital, start_time: '09:00', end_time: '12:00')
+        expect(hospital_schedule).to be_valid
+        expect(hospital_schedule.errors).to be_empty
+      end
+
+      it '両方の時間が未入力の場合にバリデーションが通るか' do
+        hospital_schedule = build(:hospital_schedule, hospital: hospital, start_time: nil, end_time: nil)
+        expect(hospital_schedule).to be_valid
+        expect(hospital_schedule.errors).to be_empty
+      end
+    end
+
+    describe '時間文字列のパース' do
+    it '文字列の時間をTime型に変換する' do
+      hospital_schedule = create(:hospital_schedule, hospital: hospital, start_time: '09:00', end_time: '12:00')
+
+      expect(hospital_schedule.start_time).to be_a(Time)
+      expect(hospital_schedule.end_time).to be_a(Time)
+      expect(hospital_schedule.start_time.hour).to eq 9
+      expect(hospital_schedule.start_time.min).to eq 0
+      expect(hospital_schedule.end_time.hour).to eq 12
+      expect(hospital_schedule.end_time.min).to eq 0
+    end
+  end
+
+  describe 'アソシエーション' do
+    it 'hospitalに属していること' do
+      association = described_class.reflect_on_association(:hospital)
+      expect(association.macro).to eq :belongs_to
+    end
+  end
 end

--- a/spec/models/hospital_spec.rb
+++ b/spec/models/hospital_spec.rb
@@ -1,5 +1,76 @@
 require 'rails_helper'
 
 RSpec.describe Hospital, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+
+  describe 'バリデーションチェック' do
+    it '設定したすべてのバリデーションが機能しているか' do
+      hospital = build(:hospital, user: user)
+      expect(hospital).to be_valid
+      expect(hospital.errors).to be_empty
+    end
+  end
+
+  describe 'name' do
+    it 'nameがない場合にバリデーションが機能してinvalidになるか' do
+      hospital = build(:hospital, user: user, name: nil)
+      expect(hospital).to be_invalid
+      expect(hospital.errors[:name]).to include('を入力してください')
+    end
+
+    it 'nameが20文字を超える場合にバリデーションが機能してinvalidになるか' do
+      hospital = build(:hospital, user: user, name: 'あ' * 21)
+      expect(hospital).to be_invalid
+      expect(hospital.errors[:name]).to include('は20文字以内で入力してください')
+    end
+  end
+
+  describe 'description' do
+    it 'descriptionが100文字を超える場合にバリデーションが機能してinvalidになるか' do
+      hospital = build(:hospital, user: user, description: 'あ' * 101)
+      expect(hospital).to be_invalid
+      expect(hospital.errors[:description]).to include('は100文字以内で入力してください')
+    end
+  end
+
+  describe 'uuid' do
+    it 'uuidが重複した場合にバリデーションが機能してinvalidになるか' do
+      uuid = SecureRandom.uuid
+      create(:hospital, user: user, uuid: uuid)
+      hospital = build(:hospital, user: user, uuid: uuid)
+      expect(hospital).to be_invalid
+      expect(hospital.errors[:uuid]).to include('はすでに存在します')
+    end
+  end
+
+  describe 'accepts_nested_attributes_for' do
+    it 'hospital_schedulesのネストした属性を受け付ける' do
+      hospital = Hospital.new(
+        name: 'テスト病院',
+        user: user,
+        hospital_schedules_attributes: [
+          { day_of_week: :monday, period: :morning, start_time: '09:00', end_time: '12:00' }
+        ]
+      )
+      expect(hospital.save).to be true
+      expect(hospital.hospital_schedules.count).to eq 1
+    end
+  end
+
+  describe 'アソシエーション' do
+    it 'userに属していること' do
+      association = described_class.reflect_on_association(:user)
+      expect(association.macro).to eq :belongs_to
+    end
+
+    it 'hospital_schedulesと関連していること' do
+      association = described_class.reflect_on_association(:hospital_schedules)
+      expect(association.macro).to eq :has_many
+    end
+
+    it 'hospital_schedulesがdependent: :destroyであること' do
+      association = described_class.reflect_on_association(:hospital_schedules)
+      expect(association.options[:dependent]).to eq :destroy
+    end
+  end
 end

--- a/spec/models/user_medicine_spec.rb
+++ b/spec/models/user_medicine_spec.rb
@@ -82,20 +82,12 @@ RSpec.describe UserMedicine, type: :model do
     end
 
     describe 'uuid' do
-      it 'uuidが被った場合にuniqueのバリデーションが機能してinvalidになるか' do
+      it 'uuidが重複した場合にuniqueのバリデーションが機能してinvalidになるか' do
         uuid = SecureRandom.uuid
         create(:user_medicine, user: user, medicine: medicine, uuid: uuid)
         user_medicine = build(:user_medicine, user: user, medicine: medicine, uuid: uuid)
         expect(user_medicine).to be_invalid
         expect(user_medicine.errors[:uuid]).to include('はすでに存在します')
-      end
-
-      it 'uuidが被らない場合はvalidになるか' do
-        medicine1 = create(:medicine, user: user)
-        medicine2 = create(:medicine, user: user)
-        create(:user_medicine, user: user, medicine: medicine1)
-        user_medicine = build(:user_medicine, user: user, medicine: medicine2)
-        expect(user_medicine).to be_valid
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -68,4 +68,36 @@ RSpec.describe User, type: :model do
       expect(user.uuid).to be_present
     end
   end
+
+  describe 'アソシエーション' do
+    it 'user_medicinesと関連していること' do
+      association = described_class.reflect_on_association(:user_medicines)
+      expect(association.macro).to eq :has_many
+    end
+
+    it 'user_medicinesがdependent: :destroyであること' do
+      association = described_class.reflect_on_association(:user_medicines)
+      expect(association.options[:dependent]).to eq :destroy
+    end
+
+    it 'medicinesと関連していること' do
+      association = described_class.reflect_on_association(:medicines)
+      expect(association.macro).to eq :has_many
+    end
+
+    it 'medicinesがdependent: :destroyであること' do
+      association = described_class.reflect_on_association(:medicines)
+      expect(association.options[:dependent]).to eq :destroy
+    end
+
+    it 'hospitalsと関連していること' do
+      association = described_class.reflect_on_association(:hospitals)
+      expect(association.macro).to eq :has_many
+    end
+
+    it 'hospitalsがdependent: :destroyであること' do
+      association = described_class.reflect_on_association(:hospitals)
+      expect(association.options[:dependent]).to eq :destroy
+    end
+  end
 end

--- a/spec/system/hospitals_spec.rb
+++ b/spec/system/hospitals_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+RSpec.describe 'Hospitals', type: :system do
+  let(:user) { create(:user) }
+
+  describe 'ログイン前' do
+    context '病院情報一覧ページへのアクセス' do
+      it 'ログインページにリダイレクトされる' do
+        visit hospital_index_path
+        expect(page).to have_content 'ログインしてください'
+        expect(current_path).to eq new_user_session_path
+      end
+    end
+  end
+
+  describe 'ログイン後' do
+    before do
+      sign_in user
+    end
+
+    describe '病院の一覧表示' do
+      context '病院が登録されていない場合' do
+        it '登録した病院が存在しない場合、メッセージが表示されること' do
+          visit hospital_index_path
+          expect(page).to have_content '現在、病院情報はありません'
+        end
+      end
+
+      context '病院情報が登録されている場合' do
+        let!(:hospital) { create(:hospital, user: user) }
+
+        it '登録した病院の一覧が表示されること' do
+          visit hospital_index_path
+
+          expect(page).to have_content(hospital.name)
+        end
+      end
+    end
+
+    describe '病院情報の新規作成' do
+      it '病院情報を登録できること' do
+        visit new_hospital_path
+
+        # 基本情報の入力
+        fill_in '病院名', with: 'クリニックA'
+        fill_in 'メモ', with: '予約優先です。'
+
+          # 月曜日の午前の時間を入力
+          select '09:00', from: 'hospital[hospital_schedules_attributes][0][start_time]'
+          select '12:00', from: 'hospital[hospital_schedules_attributes][0][end_time]'
+
+          # 月曜日の午後の時間を入力
+          select '14:00', from: 'hospital[hospital_schedules_attributes][1][start_time]'
+          select '18:00', from: 'hospital[hospital_schedules_attributes][1][end_time]'
+
+          # 火曜日の午前の時間を入力
+          select '09:00', from: 'hospital[hospital_schedules_attributes][2][start_time]'
+          select '12:00', from: 'hospital[hospital_schedules_attributes][2][end_time]'
+
+        click_button '登録'
+
+        # 登録成功の確認
+        expect(page).to have_content '病院を登録しました'
+        expect(page).to have_content 'クリニックA'
+
+        # データベースの確認
+        hospital = Hospital.last
+        expect(hospital.name).to eq 'クリニックA'
+        expect(hospital.description).to eq '予約優先です。'
+        expect(hospital.user).to eq user
+
+        # 16個のスケジュールが作成されていることを確認
+        hospital = Hospital.last
+        expect(hospital.hospital_schedules.count).to eq 16
+
+        # スケジュールの確認
+        monday_morning = hospital.hospital_schedules.find_by(day_of_week: :monday, period: :morning)
+        expect(monday_morning).to be_present
+        expect(monday_morning.start_time.strftime('%H:%M')).to eq '09:00'
+        expect(monday_morning.end_time.strftime('%H:%M')).to eq '12:00'
+
+        monday_afternoon = hospital.hospital_schedules.find_by(day_of_week: :monday, period: :afternoon)
+        expect(monday_afternoon).to be_present
+        expect(monday_afternoon.start_time.strftime('%H:%M')).to eq '14:00'
+        expect(monday_afternoon.end_time.strftime('%H:%M')).to eq '18:00'
+      end
+
+      it '病院名が空の場合はバリデーションエラーが表示されること' do
+        visit new_hospital_path
+
+          # 病院名を入力せずに診療時間だけ入力
+          select '09:00', from: 'hospital[hospital_schedules_attributes][0][start_time]'
+          select '12:00', from: 'hospital[hospital_schedules_attributes][0][end_time]'
+
+        click_button '登録'
+
+        # エラーメッセージの確認
+        expect(page).to have_content '病院名を入力してください'
+        expect(Hospital.count).to eq 0
+      end
+
+      it '開始時間が終了時間より後の場合はバリデーションエラーが表示されること' do
+        visit new_hospital_path
+
+        fill_in '病院名', with: 'テスト病院'
+
+          # 開始時間を終了時間より後に設定
+          select '12:00', from: 'hospital[hospital_schedules_attributes][0][start_time]'
+          select '09:00', from: 'hospital[hospital_schedules_attributes][0][end_time]'
+
+        click_button '登録'
+
+        # エラーメッセージの確認
+        expect(page).to have_content '終了時間は開始時間より遅い時刻に設定してください'
+        expect(Hospital.count).to eq 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
### 概要

issue [#80]、sub-issue[#171]
登録した病院情報の一覧表示を実装しました。
病院の名前と詳細ボタンをつけています。
下に新規登録ボタンを設置しています。
HospitalsとHospitalSchedulesのRspecを記述しました。

### 作業内容
**一覧表示**
- hospital/index.html.erb
詳細画面へ遷移するボタンを「選択」から「詳細」へ変更

**テスト**
1. モデルスペック
HospitalsとHospitalSchedulesのバリデーションとアソシエーションのテストを記述
- spec/models/hospital_spec.rb
- spec/models/hospital_schedule_spec.rb


2. Factory Bot
Hospitalsの複数オブジェクトを作成するFactory Botを記述、HospitalSchedulesはまだ使用していないので仮で記述
- spec/factories/hospital_spec.rb
- spec/factories/hospital_schedule_spec.rb

3. システムスペック記述
病院情報一覧と新規登録のシステムスペックを記述
spec/system/hospiral.rb


### 機能追加理由

登録した病院の詳細な診療時間を見るために、病院名だけの一覧表示がある方が見やすいと考えたため実装しました。

### 備考
issue[#79]で一覧表示はある程度実装していたため、本issueでは軽い調整をしました。
sub-issueのRspecの記述も同時に行いました。