### PR TITLE
【Test】病院情報詳細表示と削除機能のテストを記述

### DIFF
--- a/app/helpers/hospital_helper.rb
+++ b/app/helpers/hospital_helper.rb
@@ -4,9 +4,9 @@ module HospitalHelper
       s.day_of_week == day.to_s && s.period == period.to_s
     end
 
-    return "—" unless schedule&.start_time && schedule&.end_time
+    return "ー" unless schedule&.start_time && schedule&.end_time
 
-    "#{schedule.start_time.strftime('%-H:%M')}–#{schedule.end_time.strftime('%-H:%M')}"
+    "#{schedule.start_time.strftime('%-H:%M')} - #{schedule.end_time.strftime('%-H:%M')}"
   end
 
   def time_options

--- a/spec/factories/hospital_schedules.rb
+++ b/spec/factories/hospital_schedules.rb
@@ -3,8 +3,8 @@ FactoryBot.define do
     association :hospital
     day_of_week { :monday }
     period { :morning }
-    start_time { '09:00' }
-    end_time { '12:00' }
+    start_time { "09:00" }
+    end_time { "12:00" }
 
     # 休診のパターン
     trait :closed do
@@ -15,15 +15,15 @@ FactoryBot.define do
     # 午前のパターン
     trait :morning do
       period { :morning }
-      start_time { '09:00' }
-      end_time { '12:00' }
+      start_time { "09:00" }
+      end_time { "12:00" }
     end
 
     # 午後のパターン
     trait :afternoon do
       period { :afternoon }
-      start_time { '14:00' }
-      end_time { '18:00' }
+      start_time { "14:00" }
+      end_time { "18:00" }
     end
 
     # 各曜日のtrait

--- a/spec/factories/hospital_schedules.rb
+++ b/spec/factories/hospital_schedules.rb
@@ -5,5 +5,58 @@ FactoryBot.define do
     period { :morning }
     start_time { '09:00' }
     end_time { '12:00' }
+
+    # 休診のパターン
+    trait :closed do
+      start_time { nil }
+      end_time { nil }
+    end
+
+    # 午前のパターン
+    trait :morning do
+      period { :morning }
+      start_time { '09:00' }
+      end_time { '12:00' }
+    end
+
+    # 午後のパターン
+    trait :afternoon do
+      period { :afternoon }
+      start_time { '14:00' }
+      end_time { '18:00' }
+    end
+
+    # 各曜日のtrait
+    trait :monday do
+      day_of_week { :monday }
+    end
+
+    trait :tuesday do
+      day_of_week { :tuesday }
+    end
+
+    trait :wednesday do
+      day_of_week { :wednesday }
+    end
+
+    trait :thursday do
+      day_of_week { :thursday }
+    end
+
+    trait :friday do
+      day_of_week { :friday }
+    end
+
+    trait :saturday do
+      day_of_week { :saturday }
+    end
+
+    trait :sunday do
+      day_of_week { :sunday }
+    end
+
+    trait :holiday do
+      day_of_week { :holiday }
+    end
   end
 end

--- a/spec/forms/user_medicine_form_spec.rb
+++ b/spec/forms/user_medicine_form_spec.rb
@@ -1,61 +1,59 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe UserMedicineForm, type: :model do
   let(:user) { create(:user) }
 
-  describe 'バリデーション' do
-    it '全ての値が正しい場合、validになること' do
+  describe "バリデーション" do
+    it "全ての値が正しい場合、validになること" do
       form = UserMedicineForm.new(
         user: user,
-        medicine_name: '新しい薬',
+        medicine_name: "新しい薬",
         dosage_per_time: 1,
         prescribed_amount: 30,
-        date_of_prescription: Date.current
+        date_of_prescription: Date.current,
       )
       expect(form).to be_valid
     end
 
-    it 'medicine_nameがない場合、invalidになること' do
+    it "medicine_nameがない場合、invalidになること" do
       form = UserMedicineForm.new(
         user: user,
         medicine_name: nil,
         dosage_per_time: 1,
         prescribed_amount: 30,
-        date_of_prescription: Date.current
+        date_of_prescription: Date.current,
       )
       expect(form).to be_invalid
       expect(form.errors[:medicine_name]).to be_present
     end
   end
 
-  describe '薬の新規登録' do
-    context '新しい薬名の場合' do
-      it 'MedicineとUserMedicineが作成されること' do
+  describe "薬の新規登録" do
+    context "新しい薬名の場合" do
+      it "MedicineとUserMedicineが作成されること" do
         form = UserMedicineForm.new(
           user: user,
-          medicine_name: '新しい薬',
+          medicine_name: "新しい薬",
           dosage_per_time: 1,
           prescribed_amount: 30,
-          date_of_prescription: Date.current
+          date_of_prescription: Date.current,
         )
-        expect { form.save }.to change(Medicine, :count).by(1)
-                            .and change(UserMedicine, :count).by(1)
+        expect { form.save }.to change(Medicine, :count).by(1).and change(UserMedicine, :count).by(1)
       end
     end
 
-    context '既存の薬名の場合' do
-      let!(:existing_medicine) { create(:medicine, user: user, name: '既存の薬') }
+    context "既存の薬名の場合" do
+      let!(:existing_medicine) { create(:medicine, user: user, name: "既存の薬") }
 
-      it 'Medicineは作成されず、UserMedicineのみ作成されること' do
+      it "Medicineは作成されず、UserMedicineのみ作成されること" do
         form = UserMedicineForm.new(
           user: user,
-          medicine_name: '既存の薬',
+          medicine_name: "既存の薬",
           dosage_per_time: 1,
           prescribed_amount: 30,
-          date_of_prescription: Date.current
+          date_of_prescription: Date.current,
         )
-        expect { form.save }.to change(Medicine, :count).by(0)
-                            .and change(UserMedicine, :count).by(1)
+        expect { form.save }.to change(Medicine, :count).by(0).and change(UserMedicine, :count).by(1)
       end
     end
   end

--- a/spec/helpers/hospital_helper_spec.rb
+++ b/spec/helpers/hospital_helper_spec.rb
@@ -1,15 +1,67 @@
-require 'rails_helper'
+require "rails_helper"
 
-# Specs in this file have access to a helper object that includes
-# the HospitalHelper. For example:
-#
-# describe HospitalHelper do
-#   describe "string concat" do
-#     it "concats two strings with spaces" do
-#       expect(helper.concat_strings("this","that")).to eq("this that")
-#     end
-#   end
-# end
 RSpec.describe HospitalHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "#time_range" do
+    let(:hospital) { create(:hospital) }
+
+    context "診療時間が登録されている場合" do
+      let!(:schedule) do
+        create(:hospital_schedule,
+               hospital: hospital,
+               day_of_week: :monday,
+               period: :morning,
+               start_time: "09:00",
+               end_time: "12:00")
+      end
+
+      it "時間範囲が正しく表示されること" do
+        result = helper.time_range(hospital, :monday, :morning)
+        expect(result).to eq "9:00 - 12:00"
+      end
+    end
+
+    context "診療時間が登録されていない場合" do
+      it "「ー」が表示されること" do
+        result = helper.time_range(hospital, :monday, :morning)
+        expect(result).to eq "ー"
+      end
+    end
+  end
+
+  describe "#time_options" do
+    it "正しい時間選択肢が生成されること" do
+      options = helper.time_options
+
+      # 6時から23時45分まで、15分刻みで選択肢が72個
+      expect(options.length).to eq 72
+
+      # 最初の要素を確認
+      expect(options.first).to eq [ "06:00", "06:00" ]
+
+      # 最後の要素を確認
+      expect(options.last).to eq [ "23:45", "23:45" ]
+
+      # 特定の時間が含まれているか確認
+      expect(options).to include([ "09:00", "09:00" ])
+      expect(options).to include([ "12:30", "12:30" ])
+      expect(options).to include([ "18:15", "18:15" ])
+    end
+
+    it "15分刻みで生成されること" do
+      options = helper.time_options
+
+      expect(options).to include([ "09:00", "09:00" ])
+      expect(options).to include([ "09:15", "09:15" ])
+      expect(options).to include([ "09:30", "09:30" ])
+      expect(options).to include([ "09:45", "09:45" ])
+    end
+
+    it "存在しない時間が含まれていないこと" do
+      options = helper.time_options
+
+      expect(options).not_to include([ "05:00", "05:00" ])
+      expect(options).not_to include([ "24:00", "24:00" ])
+      expect(options).not_to include([ "09:10", "09:10" ])
+    end
+  end
 end

--- a/spec/models/hospital_schedule_spec.rb
+++ b/spec/models/hospital_schedule_spec.rb
@@ -1,65 +1,65 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe HospitalSchedule, type: :model do
   let(:hospital) { create(:hospital) }
 
-  describe 'バリデーションチェック' do
-    it '設定したすべてのバリデーションが機能しているか' do
+  describe "バリデーションチェック" do
+    it "設定したすべてのバリデーションが機能しているか" do
       hospital_schedule = build(:hospital_schedule, hospital: hospital)
       expect(hospital_schedule).to be_valid
       expect(hospital_schedule.errors).to be_empty
     end
   end
 
-    describe 'day_of_week' do
-      it 'day_of_weekがない場合にバリデーションが機能してinvalidになるか' do
-        hospital_schedule = build(:hospital_schedule, hospital: hospital, day_of_week: nil)
-        expect(hospital_schedule).to be_invalid
-      end
+  describe "day_of_week" do
+    it "day_of_weekがない場合にバリデーションが機能してinvalidになるか" do
+      hospital_schedule = build(:hospital_schedule, hospital: hospital, day_of_week: nil)
+      expect(hospital_schedule).to be_invalid
+    end
+  end
+
+  describe "period" do
+    it "periodがない場合にバリデーションが機能してinvalidになるか" do
+      hospital_schedule = build(:hospital_schedule, hospital: hospital, period: nil)
+      expect(hospital_schedule).to be_invalid
+    end
+  end
+
+  describe "時間のバリデーション" do
+    it "開始時間のみ入力された場合にバリデーションが機能してinvalidになるか" do
+      hospital_schedule = build(:hospital_schedule, hospital: hospital, start_time: "09:00", end_time: nil)
+      expect(hospital_schedule).to be_invalid
+      expect(hospital_schedule.errors[:end_time]).to include("を入力してください")
     end
 
-    describe 'period' do
-      it 'periodがない場合にバリデーションが機能してinvalidになるか' do
-        hospital_schedule = build(:hospital_schedule, hospital: hospital, period: nil)
-        expect(hospital_schedule).to be_invalid
-      end
+    it "終了時間のみ入力された場合にバリデーションが機能してinvalidになるか" do
+      hospital_schedule = build(:hospital_schedule, hospital: hospital, start_time: nil, end_time: "12:00")
+      expect(hospital_schedule).to be_invalid
+      expect(hospital_schedule.errors[:start_time]).to include("を入力してください")
     end
 
-    describe '時間のバリデーション' do
-      it '開始時間のみ入力された場合にバリデーションが機能してinvalidになるか' do
-        hospital_schedule = build(:hospital_schedule, hospital: hospital, start_time: '09:00', end_time: nil)
-        expect(hospital_schedule).to be_invalid
-        expect(hospital_schedule.errors[:end_time]).to include('を入力してください')
-      end
-
-      it '終了時間のみ入力された場合にバリデーションが機能してinvalidになるか' do
-        hospital_schedule = build(:hospital_schedule, hospital: hospital, start_time: nil, end_time: '12:00')
-        expect(hospital_schedule).to be_invalid
-        expect(hospital_schedule.errors[:start_time]).to include('を入力してください')
-      end
-
-      it '開始時間が終了時間より後の場合にバリデーションが機能してinvalidになるか' do
-        hospital_schedule = build(:hospital_schedule, hospital: hospital, start_time: '12:00', end_time: '09:00')
-        expect(hospital_schedule).to be_invalid
-        expect(hospital_schedule.errors[:end_time]).to include('は開始時間より遅い時刻に設定してください')
-      end
-
-      it '開始時間と終了時間が正しい場合にバリデーションが通るか' do
-        hospital_schedule = build(:hospital_schedule, hospital: hospital, start_time: '09:00', end_time: '12:00')
-        expect(hospital_schedule).to be_valid
-        expect(hospital_schedule.errors).to be_empty
-      end
-
-      it '両方の時間が未入力の場合にバリデーションが通るか' do
-        hospital_schedule = build(:hospital_schedule, hospital: hospital, start_time: nil, end_time: nil)
-        expect(hospital_schedule).to be_valid
-        expect(hospital_schedule.errors).to be_empty
-      end
+    it "開始時間が終了時間より後の場合にバリデーションが機能してinvalidになるか" do
+      hospital_schedule = build(:hospital_schedule, hospital: hospital, start_time: "12:00", end_time: "09:00")
+      expect(hospital_schedule).to be_invalid
+      expect(hospital_schedule.errors[:end_time]).to include("は開始時間より遅い時刻に設定してください")
     end
 
-    describe '時間文字列のパース' do
-    it '文字列の時間をTime型に変換する' do
-      hospital_schedule = create(:hospital_schedule, hospital: hospital, start_time: '09:00', end_time: '12:00')
+    it "開始時間と終了時間が正しい場合にバリデーションが通るか" do
+      hospital_schedule = build(:hospital_schedule, hospital: hospital, start_time: "09:00", end_time: "12:00")
+      expect(hospital_schedule).to be_valid
+      expect(hospital_schedule.errors).to be_empty
+    end
+
+    it "両方の時間が未入力の場合にバリデーションが通るか" do
+      hospital_schedule = build(:hospital_schedule, hospital: hospital, start_time: nil, end_time: nil)
+      expect(hospital_schedule).to be_valid
+      expect(hospital_schedule.errors).to be_empty
+    end
+  end
+
+  describe "時間文字列のパース" do
+    it "文字列の時間をTime型に変換する" do
+      hospital_schedule = create(:hospital_schedule, hospital: hospital, start_time: "09:00", end_time: "12:00")
 
       expect(hospital_schedule.start_time).to be_a(Time)
       expect(hospital_schedule.end_time).to be_a(Time)
@@ -70,8 +70,8 @@ RSpec.describe HospitalSchedule, type: :model do
     end
   end
 
-  describe 'アソシエーション' do
-    it 'hospitalに属していること' do
+  describe "アソシエーション" do
+    it "hospitalに属していること" do
       association = described_class.reflect_on_association(:hospital)
       expect(association.macro).to eq :belongs_to
     end

--- a/spec/models/hospital_spec.rb
+++ b/spec/models/hospital_spec.rb
@@ -1,74 +1,74 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hospital, type: :model do
   let(:user) { create(:user) }
 
-  describe 'バリデーションチェック' do
-    it '設定したすべてのバリデーションが機能しているか' do
+  describe "バリデーションチェック" do
+    it "設定したすべてのバリデーションが機能しているか" do
       hospital = build(:hospital, user: user)
       expect(hospital).to be_valid
       expect(hospital.errors).to be_empty
     end
   end
 
-  describe 'name' do
-    it 'nameがない場合にバリデーションが機能してinvalidになるか' do
+  describe "name" do
+    it "nameがない場合にバリデーションが機能してinvalidになるか" do
       hospital = build(:hospital, user: user, name: nil)
       expect(hospital).to be_invalid
-      expect(hospital.errors[:name]).to include('を入力してください')
+      expect(hospital.errors[:name]).to include("を入力してください")
     end
 
-    it 'nameが20文字を超える場合にバリデーションが機能してinvalidになるか' do
-      hospital = build(:hospital, user: user, name: 'あ' * 21)
+    it "nameが20文字を超える場合にバリデーションが機能してinvalidになるか" do
+      hospital = build(:hospital, user: user, name: "あ" * 21)
       expect(hospital).to be_invalid
-      expect(hospital.errors[:name]).to include('は20文字以内で入力してください')
+      expect(hospital.errors[:name]).to include("は20文字以内で入力してください")
     end
   end
 
-  describe 'description' do
-    it 'descriptionが100文字を超える場合にバリデーションが機能してinvalidになるか' do
-      hospital = build(:hospital, user: user, description: 'あ' * 101)
+  describe "description" do
+    it "descriptionが100文字を超える場合にバリデーションが機能してinvalidになるか" do
+      hospital = build(:hospital, user: user, description: "あ" * 101)
       expect(hospital).to be_invalid
-      expect(hospital.errors[:description]).to include('は100文字以内で入力してください')
+      expect(hospital.errors[:description]).to include("は100文字以内で入力してください")
     end
   end
 
-  describe 'uuid' do
-    it 'uuidが重複した場合にバリデーションが機能してinvalidになるか' do
+  describe "uuid" do
+    it "uuidが重複した場合にバリデーションが機能してinvalidになるか" do
       uuid = SecureRandom.uuid
       create(:hospital, user: user, uuid: uuid)
       hospital = build(:hospital, user: user, uuid: uuid)
       expect(hospital).to be_invalid
-      expect(hospital.errors[:uuid]).to include('はすでに存在します')
+      expect(hospital.errors[:uuid]).to include("はすでに存在します")
     end
   end
 
-  describe 'accepts_nested_attributes_for' do
-    it 'hospital_schedulesのネストした属性を受け付ける' do
+  describe "accepts_nested_attributes_for" do
+    it "hospital_schedulesのネストした属性を受け付ける" do
       hospital = Hospital.new(
-        name: 'テスト病院',
+        name: "テスト病院",
         user: user,
         hospital_schedules_attributes: [
-          { day_of_week: :monday, period: :morning, start_time: '09:00', end_time: '12:00' }
-        ]
+          { day_of_week: :monday, period: :morning, start_time: "09:00", end_time: "12:00" }
+        ],
       )
       expect(hospital.save).to be true
       expect(hospital.hospital_schedules.count).to eq 1
     end
   end
 
-  describe 'アソシエーション' do
-    it 'userに属していること' do
+  describe "アソシエーション" do
+    it "userに属していること" do
       association = described_class.reflect_on_association(:user)
       expect(association.macro).to eq :belongs_to
     end
 
-    it 'hospital_schedulesと関連していること' do
+    it "hospital_schedulesと関連していること" do
       association = described_class.reflect_on_association(:hospital_schedules)
       expect(association.macro).to eq :has_many
     end
 
-    it 'hospital_schedulesがdependent: :destroyであること' do
+    it "hospital_schedulesがdependent: :destroyであること" do
       association = described_class.reflect_on_association(:hospital_schedules)
       expect(association.options[:dependent]).to eq :destroy
     end

--- a/spec/models/medicine_spec.rb
+++ b/spec/models/medicine_spec.rb
@@ -1,26 +1,26 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Medicine, type: :model do
-  describe 'バリデーションチェック' do
-     let(:user) { create(:user) }
+  describe "バリデーションチェック" do
+    let(:user) { create(:user) }
 
-    it '設定したすべてのバリデーションが機能しているか' do
+    it "設定したすべてのバリデーションが機能しているか" do
       medicine = build(:medicine, user: user)
       expect(medicine).to be_valid
       expect(medicine.errors).to be_empty
     end
 
-    describe 'name' do
-      it 'nameがない場合にバリデーションが機能してinvalidになるか' do
+    describe "name" do
+      it "nameがない場合にバリデーションが機能してinvalidになるか" do
         medicine = build(:medicine, user: user, name: nil)
         expect(medicine).to be_invalid
-        expect(medicine.errors[:name]).to include('を入力してください')
+        expect(medicine.errors[:name]).to include("を入力してください")
       end
 
-      it 'nameが21文字以上の場合にバリデーションが機能してinvalidになるか' do
-        medicine = build(:medicine, user: user, name: 'a' * 21)
+      it "nameが21文字以上の場合にバリデーションが機能してinvalidになるか" do
+        medicine = build(:medicine, user: user, name: "a" * 21)
         expect(medicine).to be_invalid
-        expect(medicine.errors[:name]).to include('は20文字以内で入力してください')
+        expect(medicine.errors[:name]).to include("は20文字以内で入力してください")
       end
     end
   end

--- a/spec/models/user_medicine_spec.rb
+++ b/spec/models/user_medicine_spec.rb
@@ -1,143 +1,143 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe UserMedicine, type: :model do
-  describe 'バリデーションチェック' do
+  describe "バリデーションチェック" do
     let(:user) { create(:user) }
     let(:medicine) { create(:medicine) }
 
-    it '設定したすべてのバリデーションが機能しているか' do
+    it "設定したすべてのバリデーションが機能しているか" do
       user_medicine = build(:user_medicine, user: user)
       expect(user_medicine).to be_valid
       expect(user_medicine.errors).to be_empty
     end
 
-    describe 'medicine_id' do
-      it 'medicine_idがない場合にバリデーションが機能してinvalidになるか' do
+    describe "medicine_id" do
+      it "medicine_idがない場合にバリデーションが機能してinvalidになるか" do
         user_medicine = build(:user_medicine, user: user, medicine: nil)
         expect(user_medicine).to be_invalid
-        expect(user_medicine.errors[:medicine]).to include('を入力してください')
+        expect(user_medicine.errors[:medicine]).to include("を入力してください")
       end
     end
 
-    describe 'dosage_per_time' do
-      it 'dosage_per_timeがない場合にバリデーションが機能してinvalidになるか' do
+    describe "dosage_per_time" do
+      it "dosage_per_timeがない場合にバリデーションが機能してinvalidになるか" do
         user_medicine = build(:user_medicine, user: user, dosage_per_time: nil)
         expect(user_medicine).to be_invalid
-        expect(user_medicine.errors[:dosage_per_time]).to include('を入力してください')
+        expect(user_medicine.errors[:dosage_per_time]).to include("を入力してください")
       end
 
-      it 'dosage_per_timeが整数でない場合にバリデーションが機能してinvalidになるか' do
+      it "dosage_per_timeが整数でない場合にバリデーションが機能してinvalidになるか" do
         user_medicine = build(:user_medicine, user: user, dosage_per_time: 1.5)
         expect(user_medicine).to be_invalid
-        expect(user_medicine.errors[:dosage_per_time]).to include('は整数で入力してください')
+        expect(user_medicine.errors[:dosage_per_time]).to include("は整数で入力してください")
       end
 
-      it 'dosage_per_timeが0の場合にバリデーションが機能してinvalidになるか' do
+      it "dosage_per_timeが0の場合にバリデーションが機能してinvalidになるか" do
         user_medicine = build(:user_medicine, user: user, dosage_per_time: 0)
         expect(user_medicine).to be_invalid
-        expect(user_medicine.errors[:dosage_per_time]).to include('は1以上の値にしてください')
+        expect(user_medicine.errors[:dosage_per_time]).to include("は1以上の値にしてください")
       end
 
-      it 'dosage_per_timeが負の数の場合にバリデーションが機能してinvalidになるか' do
+      it "dosage_per_timeが負の数の場合にバリデーションが機能してinvalidになるか" do
         user_medicine = build(:user_medicine, user: user, dosage_per_time: -1)
         expect(user_medicine).to be_invalid
-        expect(user_medicine.errors[:dosage_per_time]).to include('は1以上の値にしてください')
+        expect(user_medicine.errors[:dosage_per_time]).to include("は1以上の値にしてください")
       end
 
-      it 'dosage_per_timeが1の場合にvalidになるか' do
+      it "dosage_per_timeが1の場合にvalidになるか" do
         user_medicine = build(:user_medicine, user: user, dosage_per_time: 1)
         expect(user_medicine).to be_valid
       end
     end
 
-    describe 'prescribed_amount' do
-      it 'prescribed_amountがない場合にバリデーションが機能してinvalidになるか' do
+    describe "prescribed_amount" do
+      it "prescribed_amountがない場合にバリデーションが機能してinvalidになるか" do
         user_medicine = build(:user_medicine, user: user, prescribed_amount: nil)
         expect(user_medicine).to be_invalid
-        expect(user_medicine.errors[:prescribed_amount]).to include('を入力してください')
+        expect(user_medicine.errors[:prescribed_amount]).to include("を入力してください")
       end
 
-      it 'prescribed_amountが整数でない場合にバリデーションが機能してinvalidになるか' do
+      it "prescribed_amountが整数でない場合にバリデーションが機能してinvalidになるか" do
         user_medicine = build(:user_medicine, user: user, prescribed_amount: 10.5)
         expect(user_medicine).to be_invalid
-        expect(user_medicine.errors[:prescribed_amount]).to include('は整数で入力してください')
+        expect(user_medicine.errors[:prescribed_amount]).to include("は整数で入力してください")
       end
 
-      it 'prescribed_amountが0の場合にバリデーションが機能してinvalidになるか' do
+      it "prescribed_amountが0の場合にバリデーションが機能してinvalidになるか" do
         user_medicine = build(:user_medicine, user: user, prescribed_amount: 0)
         expect(user_medicine).to be_invalid
-        expect(user_medicine.errors[:prescribed_amount]).to include('は1以上の値にしてください')
+        expect(user_medicine.errors[:prescribed_amount]).to include("は1以上の値にしてください")
       end
 
-      it 'prescribed_amountが負の数の場合にバリデーションが機能してinvalidになるか' do
+      it "prescribed_amountが負の数の場合にバリデーションが機能してinvalidになるか" do
         user_medicine = build(:user_medicine, user: user, prescribed_amount: -10)
         expect(user_medicine).to be_invalid
-        expect(user_medicine.errors[:prescribed_amount]).to include('は1以上の値にしてください')
+        expect(user_medicine.errors[:prescribed_amount]).to include("は1以上の値にしてください")
       end
 
-      it 'prescribed_amountが1の場合にvalidになるか' do
+      it "prescribed_amountが1の場合にvalidになるか" do
         user_medicine = build(:user_medicine, user: user, prescribed_amount: 1)
         expect(user_medicine).to be_valid
       end
     end
 
-    describe 'uuid' do
-      it 'uuidが重複した場合にuniqueのバリデーションが機能してinvalidになるか' do
+    describe "uuid" do
+      it "uuidが重複した場合にuniqueのバリデーションが機能してinvalidになるか" do
         uuid = SecureRandom.uuid
         create(:user_medicine, user: user, medicine: medicine, uuid: uuid)
         user_medicine = build(:user_medicine, user: user, medicine: medicine, uuid: uuid)
         expect(user_medicine).to be_invalid
-        expect(user_medicine.errors[:uuid]).to include('はすでに存在します')
+        expect(user_medicine.errors[:uuid]).to include("はすでに存在します")
       end
     end
 
-    describe 'date_of_prescription' do
-      it 'date_of_prescriptionがない場合にバリデーションが機能してinvalidになるか' do
+    describe "date_of_prescription" do
+      it "date_of_prescriptionがない場合にバリデーションが機能してinvalidになるか" do
         user_medicine = build(:user_medicine, user: user, date_of_prescription: nil)
         expect(user_medicine).to be_invalid
         expect(user_medicine.errors[:date_of_prescription]).to be_present
       end
 
-      it 'date_of_prescriptionが未来日の場合にカスタムバリデーションが機能してinvalidになるか' do
+      it "date_of_prescriptionが未来日の場合にカスタムバリデーションが機能してinvalidになるか" do
         user_medicine = build(:user_medicine, user: user, date_of_prescription: Date.tomorrow)
         expect(user_medicine).to be_invalid
         expect(user_medicine.errors[:date_of_prescription]).to be_present
       end
 
-      it 'date_of_prescriptionが今日の日付の場合にvalidになるか' do
+      it "date_of_prescriptionが今日の日付の場合にvalidになるか" do
         user_medicine = build(:user_medicine, user: user, date_of_prescription: Date.today)
         expect(user_medicine).to be_valid
       end
 
-      it 'date_of_prescriptionが過去の日付の場合にvalidになるか' do
+      it "date_of_prescriptionが過去の日付の場合にvalidになるか" do
         user_medicine = build(:user_medicine, user: user, date_of_prescription: Date.yesterday)
         expect(user_medicine).to be_valid
       end
     end
   end
 
-  describe 'カラムのデフォルト値' do
+  describe "カラムのデフォルト値" do
     let(:user) { create(:user) }
     let(:medicine) { create(:medicine) }
 
-    it 'current_stockのデフォルト値が0であること' do
+    it "current_stockのデフォルト値が0であること" do
       user_medicine = UserMedicine.new(user: user)
       expect(user_medicine.current_stock).to eq(0)
     end
 
-    it 'uuidが自動生成されること' do
+    it "uuidが自動生成されること" do
       user_medicine = create(:user_medicine, user: user, medicine: medicine)
       expect(user_medicine.uuid).to be_present
     end
   end
 
-  describe 'アソシエーション' do
-    it 'userに属していること' do
+  describe "アソシエーション" do
+    it "userに属していること" do
       association = described_class.reflect_on_association(:user)
       expect(association.macro).to eq(:belongs_to)
     end
 
-    it 'Medicineと関連していること' do
+    it "Medicineと関連していること" do
       association = described_class.reflect_on_association(:medicine)
       expect(association.macro).to eq :belongs_to
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,101 +1,101 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe User, type: :model do
-  describe 'バリデーションチェック' do
-    it '設定したすべてのバリデーションが機能しているか' do
+  describe "バリデーションチェック" do
+    it "設定したすべてのバリデーションが機能しているか" do
       user = build(:user)
       expect(user).to be_valid
       expect(user.errors).to be_empty
     end
 
-    it 'nameがない場合にバリデーションが機能してinvalidになるか' do
+    it "nameがない場合にバリデーションが機能してinvalidになるか" do
       user = build(:user, name: nil)
       expect(user).to be_invalid
-      expect(user.errors[:name]).to include('を入力してください')
+      expect(user.errors[:name]).to include("を入力してください")
     end
 
-    it 'nameが21文字以上の場合にバリデーションが機能してinvalidになるか' do
-        user = build(:user, name: 'a' * 21)
-        expect(user).to be_invalid
-        expect(user.errors[:name]).to include('は20文字以内で入力してください')
-      end
+    it "nameが21文字以上の場合にバリデーションが機能してinvalidになるか" do
+      user = build(:user, name: "a" * 21)
+      expect(user).to be_invalid
+      expect(user.errors[:name]).to include("は20文字以内で入力してください")
+    end
 
-    it 'emailがない場合にバリデーションが機能してinvalidになるか' do
+    it "emailがない場合にバリデーションが機能してinvalidになるか" do
       user = build(:user, email: nil)
       expect(user).to be_invalid
-      expect(user.errors[:email]).to include('を入力してください')
+      expect(user.errors[:email]).to include("を入力してください")
     end
 
-    it 'passwordがない場合にバリデーションが機能してinvalidになるか' do
+    it "passwordがない場合にバリデーションが機能してinvalidになるか" do
       user = build(:user, password: nil, password_confirmation: nil)
       expect(user).to be_invalid
-      expect(user.errors[:password]).to include('を入力してください')
+      expect(user.errors[:password]).to include("を入力してください")
     end
 
-    it 'emailが被った場合にuniqueのバリデーションが機能してinvalidになるか' do
-      user1 = create(:user, email: 'test@example.com')
-      user2 = build(:user, email: 'test@example.com')
+    it "emailが被った場合にuniqueのバリデーションが機能してinvalidになるか" do
+      user1 = create(:user, email: "test@example.com")
+      user2 = build(:user, email: "test@example.com")
       expect(user2).to be_invalid
-      expect(user2.errors[:email]).to include('はすでに存在します')
+      expect(user2.errors[:email]).to include("はすでに存在します")
     end
 
-    it 'emailが被らない場合はvalidになるか' do
-      user1 = create(:user, email: 'test1@example.com')
-      user2 = build(:user, email: 'test2@example.com')
+    it "emailが被らない場合はvalidになるか" do
+      user1 = create(:user, email: "test1@example.com")
+      user2 = build(:user, email: "test2@example.com")
       expect(user2).to be_valid
     end
 
-    it 'パスワードが未入力の場合はvalidになるか' do
-      user = build(:user, password: '')
+    it "パスワードが未入力の場合はvalidになるか" do
+      user = build(:user, password: "")
       expect(user).to be_invalid
-      expect(user.errors[:password]).to include('を入力してください')
+      expect(user.errors[:password]).to include("を入力してください")
     end
 
-    it 'パスワードが6文字未満の場合はinvalidになるか' do
-      user = build(:user, password: 'aaa', password_confirmation: 'aaa')
+    it "パスワードが6文字未満の場合はinvalidになるか" do
+      user = build(:user, password: "aaa", password_confirmation: "aaa")
       expect(user).to be_invalid
-      expect(user.errors[:password]).to include('は6文字以上で入力してください')
+      expect(user.errors[:password]).to include("は6文字以上で入力してください")
     end
 
-    it 'パスワードとパスワード確認が一致しない場合はinvalidになるか' do
-      user = build(:user, password: 'password123', password_confirmation: 'different')
+    it "パスワードとパスワード確認が一致しない場合はinvalidになるか" do
+      user = build(:user, password: "password123", password_confirmation: "different")
       expect(user).to be_invalid
-      expect(user.errors[:password_confirmation]).to include('とパスワードの入力が一致しません')
+      expect(user.errors[:password_confirmation]).to include("とパスワードの入力が一致しません")
     end
 
-    it 'uuidが自動生成されること' do
+    it "uuidが自動生成されること" do
       user = create(:user)
       expect(user.uuid).to be_present
     end
   end
 
-  describe 'アソシエーション' do
-    it 'user_medicinesと関連していること' do
+  describe "アソシエーション" do
+    it "user_medicinesと関連していること" do
       association = described_class.reflect_on_association(:user_medicines)
       expect(association.macro).to eq :has_many
     end
 
-    it 'user_medicinesがdependent: :destroyであること' do
+    it "user_medicinesがdependent: :destroyであること" do
       association = described_class.reflect_on_association(:user_medicines)
       expect(association.options[:dependent]).to eq :destroy
     end
 
-    it 'medicinesと関連していること' do
+    it "medicinesと関連していること" do
       association = described_class.reflect_on_association(:medicines)
       expect(association.macro).to eq :has_many
     end
 
-    it 'medicinesがdependent: :destroyであること' do
+    it "medicinesがdependent: :destroyであること" do
       association = described_class.reflect_on_association(:medicines)
       expect(association.options[:dependent]).to eq :destroy
     end
 
-    it 'hospitalsと関連していること' do
+    it "hospitalsと関連していること" do
       association = described_class.reflect_on_association(:hospitals)
       expect(association.macro).to eq :has_many
     end
 
-    it 'hospitalsがdependent: :destroyであること' do
+    it "hospitalsがdependent: :destroyであること" do
       association = described_class.reflect_on_association(:hospitals)
       expect(association.options[:dependent]).to eq :destroy
     end

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -1,8 +1,8 @@
 module LoginMacros
   def login(user)
     visit sign_in_path
-    fill_in 'メールアドレス', with: user.email
-    fill_in 'パスワード', with: 'password'
-    click_on 'ログイン'
+    fill_in "メールアドレス", with: user.email
+    fill_in "パスワード", with: "password"
+    click_on "ログイン"
   end
 end

--- a/spec/system/home/calendars_spec.rb
+++ b/spec/system/home/calendars_spec.rb
@@ -1,73 +1,73 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'カレンダー表示', type: :system do
-  describe 'カレンダー機能' do
-  let(:user) { create(:user) }
-  let!(:medicine1) { create(:medicine, name: 'テスト薬A', user: user) }
-  let!(:medicine2) { create(:medicine, name: 'テスト薬B', user: user) }
+RSpec.describe "カレンダー表示", type: :system do
+  describe "カレンダー機能" do
+    let(:user) { create(:user) }
+    let!(:medicine1) { create(:medicine, name: "テスト薬A", user: user) }
+    let!(:medicine2) { create(:medicine, name: "テスト薬B", user: user) }
 
     before do
       login_as(user)
       visit home_path
     end
 
-    context 'モーダルの表示' do
-      it '薬がない場合、この日は在庫がありませんと表示される' do
+    context "モーダルの表示" do
+      it "薬がない場合、この日は在庫がありませんと表示される" do
         click_link href: home_path(date: Date.today)
 
-        expect(page).to have_content('この日は在庫がありません。')
+        expect(page).to have_content("この日は在庫がありません。")
       end
 
-      it 'モーダルの閉じるボタンで元のページに戻る' do
+      it "モーダルの閉じるボタンで元のページに戻る" do
         click_link href: home_path(date: Date.today)
 
-        click_link '閉じる'
+        click_link "閉じる"
 
         expect(current_path).to eq(home_path)
       end
     end
 
-    context 'モーダルの挙動' do
+    context "モーダルの挙動" do
       before do
         create(:user_medicine, medicine: medicine1, dosage_per_time: 1, current_stock: 1, user: user)
       end
-      context '今日の日付をクリックすると' do
-        it '今日の在庫が表示される' do
+      context "今日の日付をクリックすると" do
+        it "今日の在庫が表示される" do
           click_link href: home_path(date: Date.today)
 
           expect(page).to have_content("#{Date.today} の在庫予定")
-          expect(page).to have_content('テスト薬A：残り1錠')
+          expect(page).to have_content("テスト薬A：残り1錠")
         end
       end
 
-      context '過去の日付をクリックすると' do
-        it '今日より前の日付の在庫は表示できません。と表示される' do
+      context "過去の日付をクリックすると" do
+        it "今日より前の日付の在庫は表示できません。と表示される" do
           click_link href: home_path(date: Date.yesterday)
 
-          expect(page).to have_content("#{ Date.yesterday} の在庫予定")
-          expect(page).to have_content('今日より前の日付の在庫は表示できません')
+          expect(page).to have_content("#{Date.yesterday} の在庫予定")
+          expect(page).to have_content("今日より前の日付の在庫は表示できません")
         end
       end
 
-      context '未来の日付をクリックすると' do
-        it 'クリックした日の在予想庫が表示される' do
+      context "未来の日付をクリックすると" do
+        it "クリックした日の在予想庫が表示される" do
           click_link href: home_path(date: Date.tomorrow)
 
           expect(page).to have_content("#{Date.tomorrow} の在庫予定")
-          expect(page).to have_content('テスト薬A：残り0錠')
+          expect(page).to have_content("テスト薬A：残り0錠")
         end
       end
     end
 
-    context 'カレンダー上の警告表示' do
+    context "カレンダー上の警告表示" do
       before do
         create(:user_medicine, medicine: medicine2, prescribed_amount: 12, date_of_prescription: Date.yesterday, dosage_per_time: 1, current_stock: 11, user: user)
         page.driver.browser.manage.window.resize_to(1200, 1000)
         visit home_path
       end
-      it '残り10錠の表示がある' do
-        expect(page).to have_content('テスト薬B10錠')
-       end
+      it "残り10錠の表示がある" do
+        expect(page).to have_content("テスト薬B10錠")
+      end
     end
   end
 end

--- a/spec/system/home/user_medicines_spec.rb
+++ b/spec/system/home/user_medicines_spec.rb
@@ -1,38 +1,38 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe '今日の在庫一覧', type: :system do
+RSpec.describe "今日の在庫一覧", type: :system do
   let(:user) { create(:user) }
 
   before do
     login_as(user)
   end
 
-  describe '今日の在庫一覧' do
-  let!(:medicine1) { create(:medicine, name: 'テスト薬A', user: user) }
-  let!(:medicine2) { create(:medicine, name: 'テスト薬B', user: user) }
+  describe "今日の在庫一覧" do
+    let!(:medicine1) { create(:medicine, name: "テスト薬A", user: user) }
+    let!(:medicine2) { create(:medicine, name: "テスト薬B", user: user) }
 
-    context '在庫のある薬がない場合' do
+    context "在庫のある薬がない場合" do
       before do
         create(:user_medicine, medicine: medicine1, current_stock: 0, user: user)
         create(:user_medicine, medicine: medicine2, current_stock: 0, user: user)
         visit home_path
       end
 
-      it '服薬中の薬はありませんと表示される' do
-        expect(page).to have_content('服薬中の薬はありません。')
+      it "服薬中の薬はありませんと表示される" do
+        expect(page).to have_content("服薬中の薬はありません。")
       end
     end
 
-    context '在庫がある薬とない薬が混在している場合' do
+    context "在庫がある薬とない薬が混在している場合" do
       before do
         create(:user_medicine, medicine: medicine1, current_stock: 5, user: user)
         create(:user_medicine, medicine: medicine2, current_stock: 0, user: user)
         visit home_path
       end
 
-      it '在庫がある薬だけが表示される' do
-        expect(page).to have_content('テスト薬A')
-        expect(page).to have_content('残り5錠')
+      it "在庫がある薬だけが表示される" do
+        expect(page).to have_content("テスト薬A")
+        expect(page).to have_content("残り5錠")
       end
     end
   end

--- a/spec/system/hospitals_spec.rb
+++ b/spec/system/hospitals_spec.rb
@@ -115,5 +115,34 @@ RSpec.describe 'Hospitals', type: :system do
         expect(Hospital.count).to eq 0
       end
     end
+
+    describe '病院の詳細表示' do
+      let!(:hospital) { create(:hospital, user: user) }
+
+      # 複数の診療時間を作成
+      let!(:monday_morning) { create(:hospital_schedule, :monday, :morning, start_time: '09:00', end_time: '12:00', hospital: hospital) }
+      let!(:monday_afternoon) { create(:hospital_schedule, :monday, :afternoon, start_time: '14:00', end_time: '18:00', hospital: hospital) }
+      let!(:tuesday_morning) { create(:hospital_schedule, :tuesday, :morning, start_time: '10:00', end_time: '13:00', hospital: hospital) }
+      # 休診の例(時間がnil)
+      let!(:wednesday_morning) { create(:hospital_schedule, :wednesday, :morning, start_time: nil, end_time: nil, hospital: hospital) }
+
+      before do
+        visit hospital_path(hospital)
+      end
+
+      it '登録した全ての項目が表示されること' do
+        expect(page).to have_content(hospital.name)
+        expect(page).to have_content(hospital.description)
+        expect(page).to have_content('月')
+        expect(page).to have_content('9:00 - 12:00')
+        expect(page).to have_content('14:00 - 18:00')
+        expect(page).to have_content('火')
+        expect(page).to have_content('10:00 - 13:00')
+      end
+
+      it '休診日は適切に表示されること' do
+        expect(page).to have_content('ー')
+      end
+    end
   end
 end

--- a/spec/system/hospitals_spec.rb
+++ b/spec/system/hospitals_spec.rb
@@ -168,5 +168,21 @@ RSpec.describe "Hospitals", type: :system do
         end
       end
     end
+
+    describe "病院情報の削除" do
+      let!(:hospital) { create(:hospital, user: user) }
+      let!(:hospital_schedule) { create(:hospital_schedule, hospital: hospital) }
+
+      before do
+        visit hospital_path(hospital)
+      end
+
+      it "病院情報が削除できること" do
+        expect(page).to have_link "削除"
+        page.accept_confirm { click_link "削除" }
+        expect(page).to have_content("病院情報を削除しました。"), "フラッシュメッセージが表示されていません"
+        expect(current_path).to eq hospital_index_path
+      end
+    end
   end
 end

--- a/spec/system/hospitals_spec.rb
+++ b/spec/system/hospitals_spec.rb
@@ -1,35 +1,35 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'Hospitals', type: :system do
+RSpec.describe "Hospitals", type: :system do
   let(:user) { create(:user) }
 
-  describe 'ログイン前' do
-    context '病院情報一覧ページへのアクセス' do
-      it 'ログインページにリダイレクトされる' do
+  describe "ログイン前" do
+    context "病院情報一覧ページへのアクセス" do
+      it "ログインページにリダイレクトされる" do
         visit hospital_index_path
-        expect(page).to have_content 'ログインしてください'
+        expect(page).to have_content "ログインしてください"
         expect(current_path).to eq new_user_session_path
       end
     end
   end
 
-  describe 'ログイン後' do
+  describe "ログイン後" do
     before do
       sign_in user
     end
 
-    describe '病院の一覧表示' do
-      context '病院が登録されていない場合' do
-        it '登録した病院が存在しない場合、メッセージが表示されること' do
+    describe "病院の一覧表示" do
+      context "病院が登録されていない場合" do
+        it "登録した病院が存在しない場合、メッセージが表示されること" do
           visit hospital_index_path
-          expect(page).to have_content '現在、病院情報はありません'
+          expect(page).to have_content "現在、病院情報はありません"
         end
       end
 
-      context '病院情報が登録されている場合' do
+      context "病院情報が登録されている場合" do
         let!(:hospital) { create(:hospital, user: user) }
 
-        it '登録した病院の一覧が表示されること' do
+        it "登録した病院の一覧が表示されること" do
           visit hospital_index_path
 
           expect(page).to have_content(hospital.name)
@@ -37,36 +37,36 @@ RSpec.describe 'Hospitals', type: :system do
       end
     end
 
-    describe '病院情報の新規作成' do
-      it '病院情報を登録できること' do
+    describe "病院情報の新規作成" do
+      it "病院情報を登録できること" do
         visit new_hospital_path
 
         # 基本情報の入力
-        fill_in '病院名', with: 'クリニックA'
-        fill_in 'メモ', with: '予約優先です。'
+        fill_in "病院名", with: "クリニックA"
+        fill_in "メモ", with: "予約優先です。"
 
-          # 月曜日の午前の時間を入力
-          select '09:00', from: 'hospital[hospital_schedules_attributes][0][start_time]'
-          select '12:00', from: 'hospital[hospital_schedules_attributes][0][end_time]'
+        # 月曜日の午前の時間を入力
+        select "09:00", from: "hospital[hospital_schedules_attributes][0][start_time]"
+        select "12:00", from: "hospital[hospital_schedules_attributes][0][end_time]"
 
-          # 月曜日の午後の時間を入力
-          select '14:00', from: 'hospital[hospital_schedules_attributes][1][start_time]'
-          select '18:00', from: 'hospital[hospital_schedules_attributes][1][end_time]'
+        # 月曜日の午後の時間を入力
+        select "14:00", from: "hospital[hospital_schedules_attributes][1][start_time]"
+        select "18:00", from: "hospital[hospital_schedules_attributes][1][end_time]"
 
-          # 火曜日の午前の時間を入力
-          select '09:00', from: 'hospital[hospital_schedules_attributes][2][start_time]'
-          select '12:00', from: 'hospital[hospital_schedules_attributes][2][end_time]'
+        # 火曜日の午前の時間を入力
+        select "09:00", from: "hospital[hospital_schedules_attributes][2][start_time]"
+        select "12:00", from: "hospital[hospital_schedules_attributes][2][end_time]"
 
-        click_button '登録'
+        click_button "登録"
 
         # 登録成功の確認
-        expect(page).to have_content '病院を登録しました'
-        expect(page).to have_content 'クリニックA'
+        expect(page).to have_content "病院を登録しました"
+        expect(page).to have_content "クリニックA"
 
         # データベースの確認
         hospital = Hospital.last
-        expect(hospital.name).to eq 'クリニックA'
-        expect(hospital.description).to eq '予約優先です。'
+        expect(hospital.name).to eq "クリニックA"
+        expect(hospital.description).to eq "予約優先です。"
         expect(hospital.user).to eq user
 
         # 16個のスケジュールが作成されていることを確認
@@ -76,53 +76,53 @@ RSpec.describe 'Hospitals', type: :system do
         # スケジュールの確認
         monday_morning = hospital.hospital_schedules.find_by(day_of_week: :monday, period: :morning)
         expect(monday_morning).to be_present
-        expect(monday_morning.start_time.strftime('%H:%M')).to eq '09:00'
-        expect(monday_morning.end_time.strftime('%H:%M')).to eq '12:00'
+        expect(monday_morning.start_time.strftime("%H:%M")).to eq "09:00"
+        expect(monday_morning.end_time.strftime("%H:%M")).to eq "12:00"
 
         monday_afternoon = hospital.hospital_schedules.find_by(day_of_week: :monday, period: :afternoon)
         expect(monday_afternoon).to be_present
-        expect(monday_afternoon.start_time.strftime('%H:%M')).to eq '14:00'
-        expect(monday_afternoon.end_time.strftime('%H:%M')).to eq '18:00'
+        expect(monday_afternoon.start_time.strftime("%H:%M")).to eq "14:00"
+        expect(monday_afternoon.end_time.strftime("%H:%M")).to eq "18:00"
       end
 
-      it '病院名が空の場合はバリデーションエラーが表示されること' do
+      it "病院名が空の場合はバリデーションエラーが表示されること" do
         visit new_hospital_path
 
-          # 病院名を入力せずに診療時間だけ入力
-          select '09:00', from: 'hospital[hospital_schedules_attributes][0][start_time]'
-          select '12:00', from: 'hospital[hospital_schedules_attributes][0][end_time]'
+        # 病院名を入力せずに診療時間だけ入力
+        select "09:00", from: "hospital[hospital_schedules_attributes][0][start_time]"
+        select "12:00", from: "hospital[hospital_schedules_attributes][0][end_time]"
 
-        click_button '登録'
+        click_button "登録"
 
         # エラーメッセージの確認
-        expect(page).to have_content '病院名を入力してください'
+        expect(page).to have_content "病院名を入力してください"
         expect(Hospital.count).to eq 0
       end
 
-      it '開始時間が終了時間より後の場合はバリデーションエラーが表示されること' do
+      it "開始時間が終了時間より後の場合はバリデーションエラーが表示されること" do
         visit new_hospital_path
 
-        fill_in '病院名', with: 'テスト病院'
+        fill_in "病院名", with: "テスト病院"
 
-          # 開始時間を終了時間より後に設定
-          select '12:00', from: 'hospital[hospital_schedules_attributes][0][start_time]'
-          select '09:00', from: 'hospital[hospital_schedules_attributes][0][end_time]'
+        # 開始時間を終了時間より後に設定
+        select "12:00", from: "hospital[hospital_schedules_attributes][0][start_time]"
+        select "09:00", from: "hospital[hospital_schedules_attributes][0][end_time]"
 
-        click_button '登録'
+        click_button "登録"
 
         # エラーメッセージの確認
-        expect(page).to have_content '終了時間は開始時間より遅い時刻に設定してください'
+        expect(page).to have_content "終了時間は開始時間より遅い時刻に設定してください"
         expect(Hospital.count).to eq 0
       end
     end
 
-    describe '病院の詳細表示' do
+    describe "病院の詳細表示" do
       let!(:hospital) { create(:hospital, user: user) }
 
       # 複数の診療時間を作成
-      let!(:monday_morning) { create(:hospital_schedule, :monday, :morning, start_time: '09:00', end_time: '12:00', hospital: hospital) }
-      let!(:monday_afternoon) { create(:hospital_schedule, :monday, :afternoon, start_time: '14:00', end_time: '18:00', hospital: hospital) }
-      let!(:tuesday_morning) { create(:hospital_schedule, :tuesday, :morning, start_time: '10:00', end_time: '13:00', hospital: hospital) }
+      let!(:monday_morning) { create(:hospital_schedule, :monday, :morning, start_time: "09:00", end_time: "12:00", hospital: hospital) }
+      let!(:monday_afternoon) { create(:hospital_schedule, :monday, :afternoon, start_time: "14:00", end_time: "18:00", hospital: hospital) }
+      let!(:tuesday_morning) { create(:hospital_schedule, :tuesday, :morning, start_time: "10:00", end_time: "13:00", hospital: hospital) }
       # 休診の例(時間がnil)
       let!(:wednesday_morning) { create(:hospital_schedule, :wednesday, :morning, start_time: nil, end_time: nil, hospital: hospital) }
 
@@ -130,18 +130,42 @@ RSpec.describe 'Hospitals', type: :system do
         visit hospital_path(hospital)
       end
 
-      it '登録した全ての項目が表示されること' do
+      it "登録した全ての項目が表示されること" do
         expect(page).to have_content(hospital.name)
         expect(page).to have_content(hospital.description)
-        expect(page).to have_content('月')
-        expect(page).to have_content('9:00 - 12:00')
-        expect(page).to have_content('14:00 - 18:00')
-        expect(page).to have_content('火')
-        expect(page).to have_content('10:00 - 13:00')
+        expect(page).to have_content("月")
+        expect(page).to have_content("9:00 - 12:00")
+        expect(page).to have_content("14:00 - 18:00")
+        expect(page).to have_content("火")
+        expect(page).to have_content("10:00 - 13:00")
       end
 
-      it '休診日は適切に表示されること' do
-        expect(page).to have_content('ー')
+      it "休診日は適切に表示されること" do
+        expect(page).to have_content("ー")
+      end
+
+      it "診療時間が表形式で表示されること" do
+        # tableタグの存在確認
+        expect(page).to have_selector("table")
+
+        # ヘッダーの確認(曜日、午前、午後)
+        within "table thead" do
+          expect(page).to have_content("曜日")
+          expect(page).to have_content("午前")
+          expect(page).to have_content("午後")
+        end
+
+        # 曜日の表示
+        within "table tbody" do
+          expect(page).to have_content("月")
+          expect(page).to have_content("火")
+          expect(page).to have_content("水")
+          expect(page).to have_content("木")
+          expect(page).to have_content("金")
+          expect(page).to have_content("土")
+          expect(page).to have_content("日")
+          expect(page).to have_content("祝")
+        end
       end
     end
   end

--- a/spec/system/user_medicines_spec.rb
+++ b/spec/system/user_medicines_spec.rb
@@ -1,90 +1,90 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "UserMedicines", type: :system do
   let(:user) { create(:user) }
   let(:medicine) { create(:medicine) }
   let(:user_medicine) { create(:user_medicine) }
 
-  describe 'ログイン前' do
-    context '薬一覧ページへのアクセス' do
-      it 'ログインページにリダイレクトされる' do
+  describe "ログイン前" do
+    context "薬一覧ページへのアクセス" do
+      it "ログインページにリダイレクトされる" do
         visit user_medicines_path
-        expect(page).to have_content 'ログインしてください'
+        expect(page).to have_content "ログインしてください"
         expect(current_path).to eq new_user_session_path
       end
     end
   end
 
-  describe 'ログイン後' do
+  describe "ログイン後" do
     before do
       sign_in user
     end
 
-    describe '薬の一覧表示' do
-      context '薬が登録されていない場合' do
-        it '「現在、薬はありません」というメッセージが表示される' do
+    describe "薬の一覧表示" do
+      context "薬が登録されていない場合" do
+        it "「現在、薬はありません」というメッセージが表示される" do
           visit user_medicines_path
-          expect(page).to have_content '現在、薬はありません'
+          expect(page).to have_content "現在、薬はありません"
         end
       end
 
-      context '薬が登録されている場合' do
-        let!(:medicine) { create(:medicine, name: 'テスト薬A') }
+      context "薬が登録されている場合" do
+        let!(:medicine) { create(:medicine, name: "テスト薬A") }
         let!(:user_medicine) do
-         create(:user_medicine,
+          create(:user_medicine,
                  user: user,
                  medicine: medicine,
-                dosage_per_time: 1)
+                 dosage_per_time: 1)
         end
 
-        it '登録した薬が表示される' do
+        it "登録した薬が表示される" do
           visit user_medicines_path
-          expect(page).to have_content 'テスト薬A'
-          expect(page).to have_content '1回の服薬量：1錠'
-          expect(page).to have_content '選択'
+          expect(page).to have_content "テスト薬A"
+          expect(page).to have_content "1回の服薬量：1錠"
+          expect(page).to have_content "選択"
         end
       end
     end
 
-    describe '薬の新規登録' do
-      context 'フォームの入力値が正常' do
-        it '薬の新規作成が成功する' do
+    describe "薬の新規登録" do
+      context "フォームの入力値が正常" do
+        it "薬の新規作成が成功する" do
           visit new_user_medicine_path
-          fill_in '薬名', with: '新しい薬'
-          fill_in '1回の服薬量', with: '1'
-          fill_in '処方量', with: '30'
-          fill_in '処方日', with: Date.current
-          click_button '薬を追加'
-          expect(page).to have_content '薬を登録しました'
+          fill_in "薬名", with: "新しい薬"
+          fill_in "1回の服薬量", with: "1"
+          fill_in "処方量", with: "30"
+          fill_in "処方日", with: Date.current
+          click_button "薬を追加"
+          expect(page).to have_content "薬を登録しました"
           expect(current_path).to eq user_medicines_path
-          expect(page).to have_content '新しい薬'
+          expect(page).to have_content "新しい薬"
         end
       end
     end
 
-    describe '薬の在庫追加' do
-       let!(:medicine) { create(:medicine) }
+    describe "薬の在庫追加" do
+      let!(:medicine) { create(:medicine) }
       let!(:user_medicine) { create(:user_medicine, user: user, medicine: medicine, current_stock: 5, dosage_per_time: 1) }
-      context 'フォームの入力値が正常' do
-        it '薬の在庫追加が成功する' do
+      context "フォームの入力値が正常" do
+        it "薬の在庫追加が成功する" do
           visit add_stock_user_medicine_path(user_medicine)
-          fill_in '処方量', with: '30'
-          fill_in '処方日', with: Date.current
-          click_button '在庫を追加'
-          expect(page).to have_content '薬を追加しました'
+          fill_in "処方量", with: "30"
+          fill_in "処方日", with: Date.current
+          click_button "在庫を追加"
+          expect(page).to have_content "薬を追加しました"
           expect(current_path).to eq user_medicines_path
         end
       end
     end
 
-    describe '薬の詳細表示' do
+    describe "薬の詳細表示" do
       let(:user_medicine) { create(:user_medicine, user: user) }
       before do
         user_medicine
         visit user_medicine_path(user_medicine)
       end
 
-      it '登録した全ての項目が表示されること' do
+      it "登録した全ての項目が表示されること" do
         expect(page).to have_content(user_medicine.medicine.name)
         expect(page).to have_content(user_medicine.dosage_per_time)
         expect(page).to have_content(user_medicine.prescribed_amount)
@@ -92,66 +92,66 @@ RSpec.describe "UserMedicines", type: :system do
       end
     end
 
-    describe '薬の飲み忘れ調整機能' do
+    describe "薬の飲み忘れ調整機能" do
       before do
-          visit user_medicine_path(user_medicine)
+        visit user_medicine_path(user_medicine)
       end
-      context '飲み忘れボタンの表示' do
-        context '在庫がある場合' do
+      context "飲み忘れボタンの表示" do
+        context "在庫がある場合" do
           let(:user_medicine) { create(:user_medicine, user: user, medicine: medicine, current_stock: 10, dosage_per_time: 2) }
-          it '飲み忘れボタンが表示される' do
-            expect(page).to have_button('飲み忘れ'), '在庫がある場合、飲み忘れボタンが表示されていません'
+          it "飲み忘れボタンが表示される" do
+            expect(page).to have_button("飲み忘れ"), "在庫がある場合、飲み忘れボタンが表示されていません"
           end
         end
 
-        context '在庫がない場合' do
+        context "在庫がない場合" do
           let(:user_medicine) { create(:user_medicine, user: user, medicine: medicine, current_stock: 0, dosage_per_time: 2) }
-          it '飲み忘れボタンが表示されない' do
-            expect(page).not_to have_button('飲み忘れ'), '在庫がない場合、飲み忘れボタンが表示されています'
+          it "飲み忘れボタンが表示されない" do
+            expect(page).not_to have_button("飲み忘れ"), "在庫がない場合、飲み忘れボタンが表示されています"
           end
         end
       end
 
-      context '飲み忘れボタンを押した場合' do
+      context "飲み忘れボタンを押した場合" do
         let(:user_medicine) { create(:user_medicine, user: user, medicine: medicine, current_stock: 10, dosage_per_time: 2) }
         before do
           visit user_medicine_path(user_medicine)
         end
 
-          it '確認ダイアログが表示され、はいを押すと在庫量が1回の服薬量分増える' do
-            accept_confirm do
-              click_button '飲み忘れ'
-            end
-
-            expect(page).to have_content('在庫を1回分増やしました'), 'フラッシュメッセージが表示されていません'
-            expect(page).to have_content('現在の在庫')
-            expect(page).to have_content('12 錠'), '在庫量の表示が正しく増えていません（期待値: 12 錠）'
-            expect(user_medicine.reload.current_stock).to eq(12), 'データベースの在庫量が正しく更新されていません（期待値: 12錠）'
+        it "確認ダイアログが表示され、はいを押すと在庫量が1回の服薬量分増える" do
+          accept_confirm do
+            click_button "飲み忘れ"
           end
 
-          it '確認ダイアログでいいえを押すと在庫量が変わらない' do
-            dismiss_confirm do
-              click_button '飲み忘れ'
-            end
+          expect(page).to have_content("在庫を1回分増やしました"), "フラッシュメッセージが表示されていません"
+          expect(page).to have_content("現在の在庫")
+          expect(page).to have_content("12 錠"), "在庫量の表示が正しく増えていません（期待値: 12 錠）"
+          expect(user_medicine.reload.current_stock).to eq(12), "データベースの在庫量が正しく更新されていません（期待値: 12錠）"
+        end
 
-            expect(page).to have_content('現在の在庫')
-            expect(page).to have_content('10 錠'), '在庫量の表示が変わってしまっています（期待値: 10 錠）'
-            expect(user_medicine.reload.current_stock).to eq(10), 'データベースの在庫量が変わってしまっています（期待値: 10錠）'
+        it "確認ダイアログでいいえを押すと在庫量が変わらない" do
+          dismiss_confirm do
+            click_button "飲み忘れ"
           end
+
+          expect(page).to have_content("現在の在庫")
+          expect(page).to have_content("10 錠"), "在庫量の表示が変わってしまっています（期待値: 10 錠）"
+          expect(user_medicine.reload.current_stock).to eq(10), "データベースの在庫量が変わってしまっています（期待値: 10錠）"
         end
       end
+    end
 
-    describe '薬の削除' do
+    describe "薬の削除" do
       let(:user_medicine) { create(:user_medicine, user: user) }
       before do
         user_medicine
         visit user_medicine_path(user_medicine)
       end
 
-      it '薬が削除できること' do
-        expect(page).to have_link '削除'
-        page.accept_confirm { click_link '削除' }
-        expect(page).to have_content('薬を削除しました。'), 'フラッシュメッセージが表示されていません'
+      it "薬が削除できること" do
+        expect(page).to have_link "削除"
+        page.accept_confirm { click_link "削除" }
+        expect(page).to have_content("薬を削除しました。"), "フラッシュメッセージが表示されていません"
         expect(current_path).to eq user_medicines_path
       end
     end

--- a/spec/system/users/edit_registrations_spec.rb
+++ b/spec/system/users/edit_registrations_spec.rb
@@ -1,34 +1,34 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'UserEditRegistrations', type: :system do
-  let(:user) { create(:user, name: '元の名前', email: 'original@example.com', password: 'password') }
+RSpec.describe "UserEditRegistrations", type: :system do
+  let(:user) { create(:user, name: "元の名前", email: "original@example.com", password: "password") }
 
   before do
     login_as(user)
   end
 
-   describe 'ユーザー情報編集' do
+  describe "ユーザー情報編集" do
     before do
       visit edit_user_registration_path
     end
 
-    context '正常系' do
-      it '名前が変更できる' do
-        fill_in '名前', with: '新しい名前'
-        fill_in '現在のパスワード', with: 'password'
-        click_button '変更する'
+    context "正常系" do
+      it "名前が変更できる" do
+        fill_in "名前", with: "新しい名前"
+        fill_in "現在のパスワード", with: "password"
+        click_button "変更する"
 
-        expect(page).to have_content('アカウント情報を変更しました。')
-        expect(page).to have_field('名前', with: '新しい名前')
+        expect(page).to have_content("アカウント情報を変更しました。")
+        expect(page).to have_field("名前", with: "新しい名前")
       end
 
-      it 'メールアドレスが変更できる' do
-        fill_in 'メールアドレス', with: 'new@example.com'
-        fill_in '現在のパスワード', with: 'password'
-        click_button '変更する'
+      it "メールアドレスが変更できる" do
+        fill_in "メールアドレス", with: "new@example.com"
+        fill_in "現在のパスワード", with: "password"
+        click_button "変更する"
 
-        expect(page).to have_content('アカウント情報を変更しました。')
-        expect(user.reload.email).to eq 'new@example.com'
+        expect(page).to have_content("アカウント情報を変更しました。")
+        expect(user.reload.email).to eq "new@example.com"
       end
 
       # it 'パスワードが変更できる' do
@@ -51,56 +51,56 @@ RSpec.describe 'UserEditRegistrations', type: :system do
       # end
     end
 
-    context '異常系' do
-      it '現在のパスワードを入力しないと変更できない' do
-        fill_in '名前', with: '新しい名前'
-        fill_in '現在のパスワード', with: ''
-        click_button '変更する'
+    context "異常系" do
+      it "現在のパスワードを入力しないと変更できない" do
+        fill_in "名前", with: "新しい名前"
+        fill_in "現在のパスワード", with: ""
+        click_button "変更する"
 
-        expect(page).to have_content('現在のパスワードを入力してください')
+        expect(page).to have_content("現在のパスワードを入力してください")
       end
 
-      it '現在のパスワードが間違っていると変更できない' do
-        fill_in '名前', with: '新しい名前'
-        fill_in '現在のパスワード', with: 'wrongpassword'
-        click_button '変更する'
+      it "現在のパスワードが間違っていると変更できない" do
+        fill_in "名前", with: "新しい名前"
+        fill_in "現在のパスワード", with: "wrongpassword"
+        click_button "変更する"
 
-        expect(page).to have_content('現在のパスワードは不正な値です')
+        expect(page).to have_content("現在のパスワードは不正な値です")
       end
     end
   end
 
-  describe 'アカウント削除' do
+  describe "アカウント削除" do
     before do
-        visit edit_user_registration_path
+      visit edit_user_registration_path
     end
 
-    it 'アカウント削除が成功する', js: true do
-        # 確認ダイアログを自動的にOKにする
-        accept_confirm do
-          click_link 'アカウント削除'
-        end
+    it "アカウント削除が成功する", js: true do
+      # 確認ダイアログを自動的にOKにする
+      accept_confirm do
+        click_link "アカウント削除"
+      end
 
-        expect(page).to have_content('アカウントを削除しました。またのご利用をお待ちしております。')
-        expect(current_path).to eq root_path
+      expect(page).to have_content("アカウントを削除しました。またのご利用をお待ちしております。")
+      expect(current_path).to eq root_path
     end
 
-    it '削除されたユーザーでログインできない' do
-        deleted_email = user.email
-        deleted_password = 'password'
+    it "削除されたユーザーでログインできない" do
+      deleted_email = user.email
+      deleted_password = "password"
 
-        accept_confirm do
-        click_link 'アカウント削除'
-        end
+      accept_confirm do
+        click_link "アカウント削除"
+      end
 
-        # 削除されたユーザーでログインを試みる
-        visit new_user_session_path
-        fill_in 'メールアドレス', with: deleted_email
-        fill_in 'パスワード', with: deleted_password
-        click_on 'ログイン'
+      # 削除されたユーザーでログインを試みる
+      visit new_user_session_path
+      fill_in "メールアドレス", with: deleted_email
+      fill_in "パスワード", with: deleted_password
+      click_on "ログイン"
 
-        expect(page).to have_content('メールアドレス もしくはパスワードが不正です。')
-        expect(current_path).to eq new_user_session_path
+      expect(page).to have_content("メールアドレス もしくはパスワードが不正です。")
+      expect(current_path).to eq new_user_session_path
     end
   end
 end

--- a/spec/system/users/new_resistrations_spec.rb
+++ b/spec/system/users/new_resistrations_spec.rb
@@ -1,33 +1,33 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'UserNewResistrations', type: :system do
+RSpec.describe "UserNewResistrations", type: :system do
   let(:user) { create(:user) }
 
-  describe 'ログイン前' do
-    describe 'ユーザー新規登録' do
-      context 'フォームの入力値が正常' do
-        it '登録に成功すること' do
+  describe "ログイン前" do
+    describe "ユーザー新規登録" do
+      context "フォームの入力値が正常" do
+        it "登録に成功すること" do
           visit new_user_registration_path
-          fill_in '名前', with: '山田太郎'
-          fill_in 'メールアドレス', with: 'example@example.com'
-          fill_in 'パスワード', with: 'example'
-          fill_in 'パスワード確認', with: 'example'
-          click_button '登録する'
-          expect(page).to have_content('アカウント登録が完了しました。')
+          fill_in "名前", with: "山田太郎"
+          fill_in "メールアドレス", with: "example@example.com"
+          fill_in "パスワード", with: "example"
+          fill_in "パスワード確認", with: "example"
+          click_button "登録する"
+          expect(page).to have_content("アカウント登録が完了しました。")
           expect(current_path).to eq home_path
         end
       end
 
-      context '異常系' do
-        it 'メールアドレスが既に登録されている場合、登録できない' do
-          existing_user = create(:user, email: 'test@example.com')
+      context "異常系" do
+        it "メールアドレスが既に登録されている場合、登録できない" do
+          existing_user = create(:user, email: "test@example.com")
           visit new_user_registration_path
-          fill_in '名前', with: '山田太郎'
-          fill_in 'メールアドレス', with: 'test@example.com'
-          fill_in 'パスワード', with: 'password'
-          fill_in 'パスワード確認', with: 'password'
-          click_button '登録する'
-          expect(page).to have_content 'メールアドレスはすでに存在します'
+          fill_in "名前", with: "山田太郎"
+          fill_in "メールアドレス", with: "test@example.com"
+          fill_in "パスワード", with: "password"
+          fill_in "パスワード確認", with: "password"
+          click_button "登録する"
+          expect(page).to have_content "メールアドレスはすでに存在します"
           expect(current_path).to eq new_user_registration_path
         end
       end

--- a/spec/system/users/sessions_spec.rb
+++ b/spec/system/users/sessions_spec.rb
@@ -1,36 +1,36 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'UserSessions', type: :system do
+RSpec.describe "UserSessions", type: :system do
   let(:user) { create(:user) }
 
-  describe 'ログイン前' do
-    context 'フォームの入力値が正常' do
-      it 'ログイン処理が成功する' do
+  describe "ログイン前" do
+    context "フォームの入力値が正常" do
+      it "ログイン処理が成功する" do
         visit new_user_session_path
-        fill_in 'メールアドレス', with: user.email
-        fill_in 'パスワード', with: 'password'
-        click_button 'ログイン'
-        expect(page).to have_content ('ログインしました。')
+        fill_in "メールアドレス", with: user.email
+        fill_in "パスワード", with: "password"
+        click_button "ログイン"
+        expect(page).to have_content ("ログインしました。")
         expect(current_path).to eq home_path
       end
     end
   end
-  describe 'ログイン後' do
+  describe "ログイン後" do
     before do
       login_as(user)
       # 画面サイズを広げる
       page.driver.browser.manage.window.resize_to(1200, 1000)
     end
 
-    context 'ログアウトボタンをクリック' do
-      it 'ログアウト処理が成功する' do
+    context "ログアウトボタンをクリック" do
+      it "ログアウト処理が成功する" do
         visit edit_user_registration_path
 
         accept_confirm do
-          click_link 'ログアウト'
+          click_link "ログアウト"
         end
 
-        expect(page).to have_content('ログアウトしました。')
+        expect(page).to have_content("ログアウトしました。")
         expect(current_path).to eq root_path
       end
     end


### PR DESCRIPTION
### 概要

issue [#173]
病院情報詳細表示と削除機能のシステムスペックとヘルパースペックを記述しました。
RspecのファイルをVSCodeのフォーマット機能を使ってインデントやクオーテーションマークを統一しました。

### 作業内容
**FactoryBot**
- spec/factories/hospital_schedules.rb
enumで定義した曜日と時間帯をtraitで定義

**ヘルパースペック**
- spec/helpers/hospital_helper_spec.rb
  - 病院情報登録の時間の表示形式が「09:00」か
  - 選択肢が6:00から23:45の範囲か

**システムスペック**
- spec/system/hospitals_spec.rb

病院情報の詳細表示
  - 登録した全ての項目が表示されること
  - 休診日は適切に表示されること
  - 診療時間が表形式で表示されること
  - 表のヘッダーに「曜日、午前、午後」が入っているか
  - 表に月から祝まで入っているか
  
病院情報の削除
  - 病院情報が削除できること

#### 備考
VSCodeのドキュメントのフォーマットをRubyを指定して行いました。rubocopで引っかかるところはrubocopを優先しました。