### PR TITLE
【Feature】通院スケジュールを登録する機能を実装

### DIFF
--- a/app/controllers/consultation_schedules_controller.rb
+++ b/app/controllers/consultation_schedules_controller.rb
@@ -7,7 +7,7 @@ class ConsultationSchedulesController < ApplicationController
     @consultation_schedule.hospital_id = @hospital.id
 
     if @consultation_schedule.save
-        redirect_to hospital_path(@hospital), notice: "診察予定日を登録しました。"
+        redirect_to hospital_path(@hospital), notice: "通院予定日を登録しました。"
     else
         @next_visit = @consultation_schedule
         flash.now[:danger] = "通院予定日登録に失敗しました。"

--- a/app/controllers/consultation_schedules_controller.rb
+++ b/app/controllers/consultation_schedules_controller.rb
@@ -10,6 +10,7 @@ class ConsultationSchedulesController < ApplicationController
         redirect_to hospital_path(@hospital), notice: "診察予定を登録しました"
     else
         @next_visit = @consultation_schedule
+        flash.now[:danger] = "通院予定日登録に失敗しました。"
         render "hospitals/show", status: :unprocessable_entity
     end
   end

--- a/app/controllers/consultation_schedules_controller.rb
+++ b/app/controllers/consultation_schedules_controller.rb
@@ -7,7 +7,7 @@ class ConsultationSchedulesController < ApplicationController
     @consultation_schedule.hospital_id = @hospital.id
 
     if @consultation_schedule.save
-        redirect_to hospital_path(@hospital), notice: "診察予定を登録しました"
+        redirect_to hospital_path(@hospital), notice: "診察予定日を登録しました。"
     else
         @next_visit = @consultation_schedule
         flash.now[:danger] = "通院予定日登録に失敗しました。"

--- a/app/controllers/consultation_schedules_controller.rb
+++ b/app/controllers/consultation_schedules_controller.rb
@@ -1,0 +1,26 @@
+class ConsultationSchedulesController < ApplicationController
+  before_action :set_hospital, only: %i[create]
+
+  def create
+    @consultation_schedule = current_user.consultation_schedules.build(consultation_schedule_params)
+    # @hospital.id を hospital_id に設定
+    @consultation_schedule.hospital_id = @hospital.id
+
+    if @consultation_schedule.save
+        redirect_to hospital_path(@hospital), notice: "診察予定を登録しました"
+    else
+        @next_visit = @consultation_schedule
+        render "hospitals/show", status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_hospital
+    @hospital = current_user.hospitals.find_by(uuid: params[:hospital_id])
+  end
+
+  def consultation_schedule_params
+    params.require(:consultation_schedule).permit(:visit_date)
+  end
+end

--- a/app/controllers/hospitals_controller.rb
+++ b/app/controllers/hospitals_controller.rb
@@ -5,6 +5,7 @@ class HospitalsController < ApplicationController
 
   def show
     @hospital = current_user.hospitals.includes(:hospital_schedules).find_by(uuid: params[:id])
+    @next_visit = @hospital.consultation_schedules.order(visit_date: :asc).first
   end
 
   def new

--- a/app/models/consultation_schedule.rb
+++ b/app/models/consultation_schedule.rb
@@ -5,5 +5,5 @@ class ConsultationSchedule < ApplicationRecord
   enum :status, { scheduled: 0, completed: 1, cancelled: 2 }
 
   validates :visit_date, presence: true
-  validates :status, presence: :ture
+  validates :status, presence: :true
 end

--- a/app/views/hospitals/show.html.erb
+++ b/app/views/hospitals/show.html.erb
@@ -5,7 +5,7 @@
       <div class="bg-white rounded-lg shadow p-6 mb-6">
         <h1 class="text-2xl md:text-3xl font-bold mb-4"><%= @hospital.name %></h1>
 
-        <%= render "schedule_table", hospital: @hospital %>
+        <%= render "hospitals/schedule_table", hospital: @hospital %>
 
         <div class="bg-white rounded-lg shadow-sm p-3 mt-4 mb-4">
           <h2 class="text-sm font-bold text-gray-800 mb-2">メモ</h2>
@@ -29,9 +29,12 @@
               method: :post do |f| %>
 
           <%= render 'shared/error_messages', object: f.object %>
-
-          <%= f.date_field :visit_date %>
-          <%= f.submit '登録' %>
+          
+         <div class="flex gap-4">
+            <%= f.date_field :visit_date,
+            min: Date.current,
+            class: "w-full border border-gray-300 rounded px-3 py-2" %>
+            <%= f.submit "登録", class: "btn btn-primary w-12" %>
         <% end %>
         </div>
     </div>

--- a/app/views/hospitals/show.html.erb
+++ b/app/views/hospitals/show.html.erb
@@ -24,10 +24,15 @@
       <div class="bg-white rounded-lg shadow p-6 mb-16">
         <div class="bg-white rounded-lg shadow-sm p-3 mt-4 mb-4">
           <h2 class="text-sm font-bold text-gray-800 mb-2">次回通院予定日</h2>
-          <p class="text-xs text-gray-500">
-            20xx年01月01日
-          </p>
-          <%= link_to "登録", "path", class: "btn btn-acsent max-w-xs" %>
+          <%= form_with model: [@hospital, @next_visit || @hospital.consultation_schedules.build],
+              url: hospital_consultation_schedules_path(@hospital),
+              method: :post do |f| %>
+
+          <%= render 'shared/error_messages', object: f.object %>
+
+          <%= f.date_field :visit_date %>
+          <%= f.submit '登録' %>
+        <% end %>
         </div>
     </div>
   </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,6 +19,8 @@ ja:
       hospital_schedules:
         start_time: 開始時間
         end_time: 終了時間
+      consultation_schedule:
+        visit_date: 通院予定日
     errors:
       models:
         medicine:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,9 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :hospitals, only: %i[index show new create edit update destroy]
+  resources :hospitals, only: %i[index show new create edit update destroy] do
+    resources :consultation_schedules, only: %i[create]
+  end
 
   devise_for :users, controllers: {
     registrations: "users/registrations",


### PR DESCRIPTION
### 概要

issue [#83]
通院スケジュールを登録する機能を実装しました。

### 作業内容
1. hospitalsにネストしたルーティングを設定
2. app/controllers/consultation_schedules_controller.rb
  - createアクションを定義
  - `set_hospital`で関連するhospitalの情報を@hospitalに代入する処理をメソッド化
  - set_hospitalをbefore_actionに設定
 3. app/views/hospitals/show.html.erb
 通院予定日を登録するフォームを作成
 4. app/controllers/hospitals_controller.rb #show
登録した通院予定日を表示するために@next_visitを定義

### 機能追加理由

通院予定日を決めて登録するとカレンダーに表示されて予定がわかりやすいため作りました。

### 確認事項
- フォームに日付を入力したらConsultationSchedulesのレコードが作成される
- 過去の日付は選択できない
- 登録後、「通院予定日を登録しました。」のフラッシュメッセージが表示される
- 登録後、フォームに登録した日付が表示される
- 登録失敗時、「通院予定日登録に失敗しました。」のフラッシュメッセージが表示される
- 登録失敗時、「通院予定日を入力してください」のエラーがフォームの上に表示される

### 備考
現段階では通院予定日登録後も登録ボタンが表示されていて、同じユーザーが同じ病院で通院予定のレコードを複数作成できてしまいますが、issue [87]でボタン表示を変更します。変更後は同じユーザー同じ病院でstatusがscheduledの通院予定日は1つしか作れない仕様にします。
