### PR TITLE
【Feature】ConsultationSchedulesのバリデーションを追加

### DIFF
--- a/app/controllers/hospitals_controller.rb
+++ b/app/controllers/hospitals_controller.rb
@@ -5,7 +5,7 @@ class HospitalsController < ApplicationController
 
   def show
     @hospital = current_user.hospitals.includes(:hospital_schedules).find_by(uuid: params[:id])
-    @next_visit = @hospital.consultation_schedules.order(visit_date: :asc).first
+    @next_visit = @hospital.consultation_schedules.upcoming.first
   end
 
   def new

--- a/app/models/consultation_schedule.rb
+++ b/app/models/consultation_schedule.rb
@@ -6,6 +6,15 @@ class ConsultationSchedule < ApplicationRecord
 
   validates :visit_date, presence: true
   validates :status, presence: :true
+  validate :visit_date_cannot_be_in_the_past
 
   scope :upcoming, -> { where(status: :scheduled).where("visit_date >= ?", Date.current).order(:visit_date) }
+
+  private
+
+  def visit_date_cannot_be_in_the_past
+    if visit_date.present? && visit_date < Date.current
+      errors.add(:visit_date, "は今日以降の日付を選択してください")
+    end
+  end
 end

--- a/app/models/consultation_schedule.rb
+++ b/app/models/consultation_schedule.rb
@@ -6,4 +6,6 @@ class ConsultationSchedule < ApplicationRecord
 
   validates :visit_date, presence: true
   validates :status, presence: :true
+
+  scope :upcoming, -> { where(status: :scheduled).where("visit_date >= ?", Date.current).order(:visit_date) }
 end

--- a/app/views/hospitals/show.html.erb
+++ b/app/views/hospitals/show.html.erb
@@ -24,12 +24,13 @@
       <div class="bg-white rounded-lg shadow p-6 mb-16">
         <div class="bg-white rounded-lg shadow-sm p-3 mt-4 mb-4">
           <h2 class="text-sm font-bold text-gray-800 mb-2">次回通院予定日</h2>
-          <%= form_with model: [@hospital, @next_visit || @hospital.consultation_schedules.build],
+          <% next_visit = @hospital.consultation_schedules.upcoming.first %>
+          <%= form_with model: next_visit || @hospital.consultation_schedules.build,
               url: hospital_consultation_schedules_path(@hospital),
               method: :post do |f| %>
 
           <%= render 'shared/error_messages', object: f.object %>
-          
+
          <div class="flex gap-4">
             <%= f.date_field :visit_date,
             min: Date.current,

--- a/app/views/hospitals/show.html.erb
+++ b/app/views/hospitals/show.html.erb
@@ -24,8 +24,7 @@
       <div class="bg-white rounded-lg shadow p-6 mb-16">
         <div class="bg-white rounded-lg shadow-sm p-3 mt-4 mb-4">
           <h2 class="text-sm font-bold text-gray-800 mb-2">次回通院予定日</h2>
-          <% next_visit = @hospital.consultation_schedules.upcoming.first %>
-          <%= form_with model: next_visit || @hospital.consultation_schedules.build,
+          <%= form_with model: [@hospital, @next_visit || @hospital.consultation_schedules.build],
               url: hospital_consultation_schedules_path(@hospital),
               method: :post do |f| %>
 

--- a/app/views/hospitals/show.html.erb
+++ b/app/views/hospitals/show.html.erb
@@ -25,18 +25,17 @@
         <div class="bg-white rounded-lg shadow-sm p-3 mt-4 mb-4">
           <h2 class="text-sm font-bold text-gray-800 mb-2">次回通院予定日</h2>
           <%= form_with model: [@hospital, @next_visit || @hospital.consultation_schedules.build],
-              url: hospital_consultation_schedules_path(@hospital),
-              method: :post do |f| %>
+                        url: hospital_consultation_schedules_path(@hospital),
+                        method: :post do |f| %>
 
-          <%= render 'shared/error_messages', object: f.object %>
-
-         <div class="flex gap-4">
-            <%= f.date_field :visit_date,
-            min: Date.current,
-            class: "w-full border border-gray-300 rounded px-3 py-2" %>
-            <%= f.submit "登録", class: "btn btn-primary w-12" %>
-        <% end %>
+            <%= render "shared/error_messages", object: f.object %>
+            <div class="flex gap-4">
+              <%= f.date_field :visit_date,
+                               min: Date.current,
+                               class: "w-full border border-gray-300 rounded px-3 py-2" %>
+              <%= f.submit "登録", class: "btn btn-primary w-12" %>
+          <% end %>
         </div>
-    </div>
+     </div>
   </div>
 </div>


### PR DESCRIPTION
### 概要

issue [#86]
通院予定の日付のカスタムバリデーションを作り、フォームに表示する予定日を絞り込むscopeを定義しました。

### 作業内容
**カスタムバリデーション**
1. app/models/consultation_schedule.rb
DBに過去の日付が保存できないように`visit_date_cannot_be_in_the_past`バリデーションを追加

**scope**
1. app/models/consultation_schedule.rb
statusがscheduledで通院予定日が今日以降のレコードを絞り込む`upcoming`を定義
3. app/controllers/hospitals_controller.rb
@next_visit変数に渡すレコードがupcomingで絞り込まれるように修正


### 確認事項
`visit_date_cannot_be_in_the_past`の確認のため、通院予定日のフォームにある`min: Date.current`を一時的に外して過去の日付を入力し、エラーが出ることを確認しました。
`upcoming`をつけることで通院予定日が過ぎたフォームは空欄に戻ることを確認しました。

### 機能追加理由
`min: Date.current`でユーザーは過去の日付を選択できませんが、DBレベルでデータの整合性を保証し二重チェックを行うためバリデーションを追加しました。
コードを簡潔に記述するためにscopeで`upcoming`を定義しました。
