### PR TITLE
【feautre】通院予定日を変更する機能を実装

### DIFF
--- a/app/controllers/consultation_schedules_controller.rb
+++ b/app/controllers/consultation_schedules_controller.rb
@@ -1,5 +1,6 @@
 class ConsultationSchedulesController < ApplicationController
-  before_action :set_hospital, only: %i[create]
+  before_action :set_hospital, only: %i[create update]
+  before_action :set_consultation_schedule, only: %i[update]
 
   def create
     @consultation_schedule = current_user.consultation_schedules.build(consultation_schedule_params)
@@ -15,10 +16,25 @@ class ConsultationSchedulesController < ApplicationController
     end
   end
 
+  def update
+    if @consultation_schedule.update(consultation_schedule_params)
+      redirect_to hospital_path(@hospital), notice: "通院予定日を変更しました。"
+    else
+      # @consultation_scheduleにエラー情報を含むオブジェクトごとビューの@next_visitに渡す
+      @next_visit = @consultation_schedule
+      flash.now[:danger] = "通院予定日変更に失敗しました。"
+      render "hospitals/show", status: :unprocessable_entity
+    end
+  end
+
   private
 
   def set_hospital
     @hospital = current_user.hospitals.find_by(uuid: params[:hospital_id])
+  end
+
+  def set_consultation_schedule
+    @consultation_schedule = current_user.consultation_schedules.find(params[:id])
   end
 
   def consultation_schedule_params

--- a/app/views/hospitals/show.html.erb
+++ b/app/views/hospitals/show.html.erb
@@ -24,16 +24,14 @@
       <div class="bg-white rounded-lg shadow p-6 mb-16">
         <div class="bg-white rounded-lg shadow-sm p-3 mt-4 mb-4">
           <h2 class="text-sm font-bold text-gray-800 mb-2">次回通院予定日</h2>
-          <%= form_with model: [@hospital, @next_visit || @hospital.consultation_schedules.build],
-                        url: hospital_consultation_schedules_path(@hospital),
-                        method: :post do |f| %>
-
+          <% consultation_schedule = @next_visit || @hospital.consultation_schedules.build %>
+          <%= form_with model: [@hospital, consultation_schedule] do |f| %>
             <%= render "shared/error_messages", object: f.object %>
             <div class="flex gap-4">
               <%= f.date_field :visit_date,
                                min: Date.current,
                                class: "w-full border border-gray-300 rounded px-3 py-2" %>
-              <%= f.submit "登録", class: "btn btn-primary w-12" %>
+              <%= f.submit nil, class: "btn btn-primary w-12" %>
           <% end %>
         </div>
      </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -65,3 +65,7 @@ ja:
       period:
         morning: "午前"
         afternoon: "午後"
+  helpers:
+    submit:
+      create: 登録
+      update: 変更

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   end
 
   resources :hospitals, only: %i[index show new create edit update destroy] do
-    resources :consultation_schedules, only: %i[create]
+    resources :consultation_schedules, only: %i[create update]
   end
 
   devise_for :users, controllers: {

--- a/spec/system/hospitals_spec.rb
+++ b/spec/system/hospitals_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe "Hospitals", type: :system do
         select "12:00", from: "hospital[hospital_schedules_attributes][0][start_time]"
         select "09:00", from: "hospital[hospital_schedules_attributes][0][end_time]"
 
-        click_button "登録する"
+        click_button "登録"
 
         # エラーメッセージの確認
         expect(page).to have_content "終了時間は開始時間より遅い時刻に設定してください"
@@ -194,7 +194,7 @@ RSpec.describe "Hospitals", type: :system do
           visit edit_hospital_path(hospital)
 
           fill_in "病院名", with: "新しい病院名"
-          click_button "更新する"
+          click_button "変更"
 
           expect(page).to have_content "病院情報を更新しました"
           expect(page).to have_content "新しい病院名"
@@ -204,7 +204,7 @@ RSpec.describe "Hospitals", type: :system do
           visit edit_hospital_path(hospital)
 
           fill_in "メモ", with: "新しいメモ内容"
-          click_button "更新する"
+          click_button "変更"
 
           expect(page).to have_content "病院情報を更新しました"
           expect(page).to have_content "新しいメモ内容"
@@ -220,7 +220,7 @@ RSpec.describe "Hospitals", type: :system do
           select "10:00", from: "hospital_hospital_schedules_attributes_1_start_time"
           select "13:00", from: "hospital_hospital_schedules_attributes_1_end_time"
 
-          click_button "更新する"
+          click_button "変更"
 
           sleep 5
           expect(current_path).to eq hospital_path(hospital)


### PR DESCRIPTION
### 概要

issue [#87]
登録済みの通院予定を変更できるようにしました。

### 作業内容
1. config/routes.rb
updateのルーティングを追加
2. app/controllers/consultation_schedules_controller.rb
  - 登録済みの通院予定日を取得して`@consultation_schedule`に代入する処理をbefore_actionで定義
  - レコードをupdateする処理をcreateアクションに記述
3. config/locales/ja.yml
submitにnilを渡した際に表示されるボタンの文字を修正
### 機能追加理由

予定を変更した場合に対処するために実装しました。

### 確認事項
**成功時**
- railsコンソールで値が更新されている
- ブラウザ上で変更ボタンを押すとフラッシュメッセージで「通院予定日を変更しました。」と表示される

**失敗時**
- 不正な値を入力して変更ボタンを押すとフラッシュメッセージで「通院予定日変更に失敗しました」と表示される
  - エラー内容がフォームの上に表示される

**表示**
- 通院予定日のフォームに表示がない場合、「登録」ボタンが表示される
- 通院予定日のフォームに表示がすでにある場合、「変更」ボタンが表示される
