### PR TITLE
【Test】ConsultationSchedulesのモデルスペックとシステムスペック記述

### DIFF
--- a/app/views/hospitals/show.html.erb
+++ b/app/views/hospitals/show.html.erb
@@ -30,7 +30,7 @@
             <div class="flex gap-4">
               <%= f.date_field :visit_date,
                                min: Date.current,
-                               class: "w-full border border-gray-300 rounded px-3 py-2" %>
+                               class: "border border-gray-300 rounded px-3 py-2" %>
               <%= f.submit nil, class: "btn btn-primary w-12" %>
           <% end %>
         </div>

--- a/spec/factories/consultation_schedules.rb
+++ b/spec/factories/consultation_schedules.rb
@@ -1,4 +1,8 @@
 FactoryBot.define do
-  factory :consultaiton_schedule do
+  factory :consultation_schedule do
+    visit_date { Date.current }
+    status { :scheduled }
+    association :user
+    association :hospital
   end
 end

--- a/spec/models/consultation_schedule_spec.rb
+++ b/spec/models/consultation_schedule_spec.rb
@@ -1,5 +1,57 @@
 require 'rails_helper'
 
 RSpec.describe ConsultationSchedule, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+  let(:hospital) { create(:hospital) }
+
+  describe "バリデーションチェック" do
+    it "設定したすべてのバリデーションが機能しているか" do
+      consultation_schedule = build(:consultation_schedule, user: user)
+      expect(consultation_schedule).to be_valid
+      expect(consultation_schedule.errors).to be_empty
+    end
+
+    describe "visit_date" do
+      it "visit_dateがない場合にバリデーションが機能してinvalidになるか" do
+        consultation_schedule = build(:consultation_schedule, user: user, visit_date: nil)
+        expect(consultation_schedule).to be_invalid
+        expect(consultation_schedule.errors[:visit_date]).to include("を入力してください")
+      end
+
+      it "visit_dateが過去の場合にカスタムバリデーションが機能してinvalidになるか" do
+        consultation_schedule = build(:consultation_schedule, user: user, visit_date: Date.yesterday)
+        expect(consultation_schedule).to be_invalid
+        expect(consultation_schedule.errors[:visit_date]).to be_present
+      end
+    end
+
+    describe "status" do
+      it "statusがない場合にバリデーションが機能してinvalidになるか" do
+        consultation_schedule = build(:consultation_schedule, user: user, status: nil)
+        expect(consultation_schedule).to be_invalid
+        expect(consultation_schedule.errors[:status]).to include("を入力してください")
+      end
+    end
+  end
+
+  describe "カラムのデフォルト値" do
+    let(:user) { create(:user) }
+    let(:hospital) { create(:hospital) }
+    it "statusのデフォルト値がscheduledであること" do
+      consultation_schedule = build(:consultation_schedule, user: user)
+       expect(consultation_schedule.status).to eq("scheduled")
+    end
+  end
+
+  describe "アソシエーション" do
+    it "userに属していること" do
+      association = described_class.reflect_on_association(:user)
+      expect(association.macro).to eq(:belongs_to)
+    end
+
+    it "hospitalに属していること" do
+      association = described_class.reflect_on_association(:hospital)
+      expect(association.macro).to eq :belongs_to
+    end
+  end
 end

--- a/spec/models/user_medicine_spec.rb
+++ b/spec/models/user_medicine_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe UserMedicine, type: :model do
         expect(user_medicine.errors[:date_of_prescription]).to be_present
       end
 
-      it "date_of_prescriptionが未来日の場合にカスタムバリデーションが機能してinvalidになるか" do
+      it "date_of_prescriptionが未来の場合にカスタムバリデーションが機能してinvalidになるか" do
         user_medicine = build(:user_medicine, user: user, date_of_prescription: Date.tomorrow)
         expect(user_medicine).to be_invalid
         expect(user_medicine.errors[:date_of_prescription]).to be_present

--- a/spec/system/consultation_schedules_spec.rb
+++ b/spec/system/consultation_schedules_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe "ConsultationSchedules", type: :system do
     sign_in user
   end
 
-  describe '通院予定の表示' do
-    context '通院予定がない場合' do
-      it 'フォームが空欄で表示される' do
+  describe "通院予定の表示" do
+    context "通院予定がない場合" do
+      it "フォームが空欄で表示される" do
         visit hospital_path(hospital)
 
-        expect(page).to have_field('consultation_schedule[visit_date]', with: '')
+        expect(page).to have_field("consultation_schedule[visit_date]", with: "")
       end
     end
 
@@ -29,38 +29,38 @@ RSpec.describe "ConsultationSchedules", type: :system do
     #   end
     # end
 
-    context '通院予定がある場合（statusがscheduledでvisit_dateが未来）' do
+    context "通院予定がある場合（statusがscheduledでvisit_dateが未来）" do
       let(:future_date) { 5.days.from_now.to_date }
 
       before do
         create(:consultation_schedule, user: user, hospital: hospital, status: :scheduled, visit_date: future_date)
       end
 
-      it 'フォームに通院予定日が表示される' do
+      it "フォームに通院予定日が表示される" do
         visit hospital_path(hospital)
 
-        expect(page).to have_field('consultation_schedule[visit_date]', with: future_date.to_s)
+        expect(page).to have_field("consultation_schedule[visit_date]", with: future_date.to_s)
       end
     end
   end
 
-  describe '通院予定の作成' do
+  describe "通院予定の作成" do
     let(:visit_date) { 7.days.from_now.to_date }
 
-    context '正常な入力の場合' do
-      it '通院予定日を登録できる' do
+    context "正常な入力の場合" do
+      it "通院予定日を登録できる" do
         visit hospital_path(hospital)
 
-        fill_in 'consultation_schedule[visit_date]', with: visit_date
-        click_button '登録'
+        fill_in "consultation_schedule[visit_date]", with: visit_date
+        click_button "登録"
 
-        expect(page).to have_content '通院予定日を登録しました。'
-        expect(page).to have_field('consultation_schedule[visit_date]', with: visit_date.to_s)
+        expect(page).to have_content "通院予定日を登録しました。"
+        expect(page).to have_field("consultation_schedule[visit_date]", with: visit_date.to_s)
       end
     end
   end
 
-  describe '通院予定の変更' do
+  describe "通院予定の変更" do
     let(:initial_date) { 5.days.from_now.to_date }
     let(:new_date) { 10.days.from_now.to_date }
 
@@ -68,15 +68,15 @@ RSpec.describe "ConsultationSchedules", type: :system do
       create(:consultation_schedule, user: user, hospital: hospital, status: :scheduled, visit_date: initial_date)
     end
 
-    context '正常な入力の場合' do
-      it '通院予定日を更新できる' do
+    context "正常な入力の場合" do
+      it "通院予定日を更新できる" do
         visit hospital_path(hospital)
 
-        fill_in 'consultation_schedule[visit_date]', with: new_date
-        click_button '変更'
+        fill_in "consultation_schedule[visit_date]", with: new_date
+        click_button "変更"
 
-        expect(page).to have_content '通院予定日を変更しました。'
-        expect(page).to have_field('consultation_schedule[visit_date]', with: new_date.to_s)
+        expect(page).to have_content "通院予定日を変更しました。"
+        expect(page).to have_field("consultation_schedule[visit_date]", with: new_date.to_s)
       end
     end
   end


### PR DESCRIPTION
### 概要

issue [#183]
ConsultationSchedulesのモデルスペックとFactoryBot、通院予定日作成、表示、変更のシステムスペックを記述しました。

### 作業内容
**FactoryBot**
spec/factories/consultation_spec.rb
- 通院予定のオブジェクトを作成

**モデルスペック**
spec/models/consultation_schedule_spec.rb
- バリデーションチェック
  - 設定したすべてのバリデーションが機能しているか
  - visit_dateがない場合にバリデーションが機能してinvalidになるか
  - visit_dateが過去の場合にカスタムバリデーションが機能してinvalidになるか
  - statusがない場合にバリデーションが機能してinvalidになるか
  - statusのデフォルト値がscheduledであること
  
- アソシエーション
  - userに属していること
  - hospitalに属していること

**システムスペック**
spec/system/consultation_schedules_spec.rb
通院予定の表示
- 通院予定がない場合、フォームが空欄で表示される
- 通院予定がある場合、フォームに通院予定日が表示される
- statusがscheduledだがvisit_dateが過去の場合、フォームが空欄で表示される

通院予定の作成
- 正常な入力の場合、通院予定日を登録できる
- 入力が不正な場合、エラーメッセージが表示される

通院予定の変更
- 正常な入力の場合、通院予定日を更新できる
- 入力が不正な場合、エラーメッセージが表示される
