### PR TITLE
【remove】 通院予定のstatusカラムを削除

### DIFF
--- a/app/models/consultation_schedule.rb
+++ b/app/models/consultation_schedule.rb
@@ -2,13 +2,10 @@ class ConsultationSchedule < ApplicationRecord
   belongs_to :user
   belongs_to :hospital
 
-  enum :status, { scheduled: 0, completed: 1 }
-
   validates :visit_date, presence: true
-  validates :status, presence: :true
   validate :visit_date_cannot_be_in_the_past
 
-  scope :upcoming, -> { where(status: :scheduled).where("visit_date >= ?", Date.current).order(:visit_date) }
+  scope :upcoming, -> { where("visit_date >= ?", Date.current).order(:visit_date) }
   scope :past_scheduled, -> { where("visit_date < ?", Date.current) }
 
   private

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,5 +6,4 @@ set :environment, rails_env
 set :output, "#{Rails.root}/log/cron.log"
 every 1.day, at: "0:00 am" do
   rake "medicine_stock:reduce_medicine_stock"
-  rake "consultation_schedule:update_status"
 end

--- a/db/migrate/20260203084928_remove_status_from_consultation_schedules.rb
+++ b/db/migrate/20260203084928_remove_status_from_consultation_schedules.rb
@@ -1,0 +1,5 @@
+class RemoveStatusFromConsultationSchedules < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :consultation_schedules, :status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_30_011325) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_03_084928) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,7 +18,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_30_011325) do
     t.bigint "user_id", null: false
     t.bigint "hospital_id", null: false
     t.date "visit_date", null: false
-    t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["hospital_id"], name: "index_consultation_schedules_on_hospital_id"

--- a/lib/tasks/consultation_schedule.rake
+++ b/lib/tasks/consultation_schedule.rake
@@ -1,6 +1,0 @@
-namespace :consultation_schedule do
-  desc "通院予定日が過ぎた予定のstatusをcompletedに変更する"
-  task update_status: :environment do
-    ConsultationSchedule.scheduled.past_scheduled.find_each(&:completed!)
-  end
-end

--- a/spec/factories/consultation_schedules.rb
+++ b/spec/factories/consultation_schedules.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :consultation_schedule do
     visit_date { Date.current }
-    status { :scheduled }
     association :user
     association :hospital
   end

--- a/spec/models/consultation_schedule_spec.rb
+++ b/spec/models/consultation_schedule_spec.rb
@@ -24,23 +24,6 @@ RSpec.describe ConsultationSchedule, type: :model do
         expect(consultation_schedule.errors[:visit_date]).to be_present
       end
     end
-
-    describe "status" do
-      it "statusがない場合にバリデーションが機能してinvalidになるか" do
-        consultation_schedule = build(:consultation_schedule, user: user, status: nil)
-        expect(consultation_schedule).to be_invalid
-        expect(consultation_schedule.errors[:status]).to include("を入力してください")
-      end
-    end
-  end
-
-  describe "カラムのデフォルト値" do
-    let(:user) { create(:user) }
-    let(:hospital) { create(:hospital) }
-    it "statusのデフォルト値がscheduledであること" do
-      consultation_schedule = build(:consultation_schedule, user: user)
-       expect(consultation_schedule.status).to eq("scheduled")
-    end
   end
 
   describe "アソシエーション" do

--- a/spec/system/consultation_schedules_spec.rb
+++ b/spec/system/consultation_schedules_spec.rb
@@ -18,38 +18,17 @@ RSpec.describe "ConsultationSchedules", type: :system do
       end
     end
 
-    context "通院予定がある場合（statusがscheduledでvisit_dateが未来）" do
+    context "通院予定がある場合" do
       let(:future_date) { 5.days.from_now.to_date }
 
       before do
-        create(:consultation_schedule, user: user, hospital: hospital, status: :scheduled, visit_date: future_date)
+        create(:consultation_schedule, user: user, hospital: hospital, visit_date: future_date)
       end
 
       it "フォームに通院予定日が表示される" do
         visit hospital_path(hospital)
 
         expect(page).to have_field("consultation_schedule[visit_date]", with: future_date.to_s, disabled: true)
-      end
-    end
-
-    # バッチ処理の失敗などでcompletedに更新されなかった場合を想定
-    context "statusがscheduledだがvisit_dateが過去の場合" do
-      let(:past_date) { 3.days.ago.to_date }
-
-      before do
-        # バリデーションをスキップして過去日付のデータを作成
-        consultation_schedule = build(:consultation_schedule,
-                                      user: user,
-                                      hospital: hospital,
-                                      status: :scheduled,
-                                      visit_date: past_date)
-        consultation_schedule.save(validate: false)
-      end
-
-      it "フォームが空欄で表示される" do
-        visit hospital_path(hospital)
-
-        expect(page).to have_field("consultation_schedule[visit_date]", with: "", disabled: true)
       end
     end
   end
@@ -79,7 +58,7 @@ RSpec.describe "ConsultationSchedules", type: :system do
     let(:new_date) { 10.days.from_now.to_date }
 
     before do
-      create(:consultation_schedule, user: user, hospital: hospital, status: :scheduled, visit_date: initial_date)
+      create(:consultation_schedule, user: user, hospital: hospital, visit_date: initial_date)
     end
 
     context "正常な入力の場合" do


### PR DESCRIPTION
### 概要

issue [#189]
予定の状態を判断する必要がなくなったため、ConsultaitonSchedulesテーブルのstatusカラムを削除しました。
理由は、通院予定の履歴を使用する機能の実装予定がないことと、当初statusカラムにenumでcanceledを定義していましたが、物理削除を採用したため使わなかったため、statusの状態はscheduledのみで十分なためです。

### 作業内容
1. マイグレーションファイルを作成
 `docker compose exec web bin/rails g migration RemoveStatusFromConsultationSchedules status:integer`
2. マイグレーション実行
3. app/models/consultation_schedule.rb
  - statusのバリデーションを削除
  - scope`upcoming`を修正
4. テスト関連のstatusの記述を削除

**status自動更新関連**
status自動更新関連のファイルを削除しました。
- lib/tasks/consultation_schedule.rake
- config/schedule.rbの`consultation_schedule:update_status`

### 確認事項
通院予定の作成、表示、更新、削除が問題なくできることを確認しました。
