### PR TITLE
【test】通院予定日がカレンダーに表示されるテストを記述

### DIFF
--- a/spec/models/consultation_schedule_spec.rb
+++ b/spec/models/consultation_schedule_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe ConsultationSchedule, type: :model do
         expect(consultation_schedule).to be_invalid
         expect(consultation_schedule.errors[:visit_date]).to be_present
       end
+
+      it "visit_dateが6ヶ月先以降の場合にカスタムバリデーションが機能してinvalidになるか" do
+        consultation_schedule = build(:consultation_schedule, user: user, visit_date: 7.months.from_now.to_date)
+        expect(consultation_schedule).to be_invalid
+        expect(consultation_schedule.errors[:visit_date]).to be_present
+      end
     end
   end
 

--- a/spec/system/home/calendars_spec.rb
+++ b/spec/system/home/calendars_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "カレンダー表示", type: :system do
       end
 
       context "1ヶ月以上前に遷移しようとする場合" do
-        it "「1ヶ月以上前は表示できません」のメッセージが表示される" do
+        it "ブラウザのアラートが表示される" do
           # まず1ヶ月前に遷移
           click_link "前月"
 

--- a/spec/system/home/calendars_spec.rb
+++ b/spec/system/home/calendars_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "カレンダー表示", type: :system do
     let(:user) { create(:user) }
     let!(:medicine1) { create(:medicine, name: "テスト薬A", user: user) }
     let!(:medicine2) { create(:medicine, name: "テスト薬B", user: user) }
+    let!(:hospital) { create(:hospital, user: user, name: "病院A") }
 
     before do
       login_as(user)
@@ -59,14 +60,84 @@ RSpec.describe "カレンダー表示", type: :system do
       end
     end
 
-    context "カレンダー上の警告表示" do
+    context "カレンダー上の表示" do
       before do
         create(:user_medicine, medicine: medicine2, prescribed_amount: 12, date_of_prescription: Date.yesterday, dosage_per_time: 1, current_stock: 11, user: user)
+        create(:consultation_schedule, user: user, hospital: hospital, visit_date: Date.current)
         page.driver.browser.manage.window.resize_to(1200, 1000)
         visit home_path
       end
       it "残り10錠の表示がある" do
         expect(page).to have_content("テスト薬B10錠")
+      end
+
+      it "通院予定の表示がある" do
+        expect(page).to have_content("病院A通院予定")
+      end
+    end
+
+    describe "前月ボタンの動作" do
+      current_month = Time.current.strftime("%Y年%m月")
+      previous_month = 1.month.ago.strftime("%Y年%m月")
+
+      context "1ヶ月前に遷移する場合" do
+        it "正常に前月のカレンダーが表示される" do
+          # 現在の月が表示されていることを確認
+          expect(page).to have_content(current_month)
+
+          # 前月ボタンをクリック
+          click_link "前月"
+
+          # 前月のカレンダーが表示されることを確認
+          expect(page).to have_content(previous_month)
+        end
+      end
+
+      context "1ヶ月以上前に遷移しようとする場合" do
+        it "「1ヶ月以上前は表示できません」のメッセージが表示される" do
+          # まず1ヶ月前に遷移
+          click_link "前月"
+
+          # 次のクリックでアラートが表示される
+          accept_alert "1ヶ月以上前は表示できません" do
+            click_button "前月"
+          end
+
+          # ページが遷移していないことを確認（1ヶ月のまま）
+          expect(page).to have_content(previous_month)
+        end
+      end
+    end
+
+    describe "次月ボタンの動作" do
+      context "6ヶ月先まで遷移する場合" do
+        it "正常に次月のカレンダーが表示される" do
+          6.times do |i|
+            target_month = (i + 1).months.from_now.strftime("%Y年%m月")
+
+            # 次月ボタンをクリック
+            click_link "次月"
+
+            # 対象月のカレンダーが表示されることを確認
+            expect(page).to have_content(target_month)
+          end
+        end
+      end
+
+      context "6ヶ月より先に遷移しようとする場合" do
+        it "ブラウザのアラートが表示される" do
+          # 6ヶ月先まで遷移
+          6.times { click_link "次月" }
+
+          # 7回目のクリックでアラートが表示される
+          accept_alert "6ヶ月先以降は表示できません" do
+            # ボタンのテキストで指定（テキスト内の矢印も含める）
+            click_button "次月"
+          end
+
+          # ページが遷移していないことを確認（6ヶ月先のまま）
+          expect(page).to have_content(6.months.from_now.strftime("%Y年%m月"))
+        end
       end
     end
   end


### PR DESCRIPTION
### 概要

[#192]
登録した通院予定がカレンダー上に表示されること、カレンダーが1ヶ月前から6ヶ月後までしか表示できないこと、visit_dateのバリデーションのテストを記述しました。

### 作業内容

- spec/system/home/calendars_spec.rb
  - 通院予定の表示がある
  - 1ヶ月前に遷移する場合、正常に前月のカレンダーが表示される
  - 1ヶ月以上前に遷移しようとする場合、「1ヶ月以上前は表示できません」のアラートが表示される
  - 6ヶ月先まで遷移する場合、正常に次月のカレンダーが表示される
  - 6ヶ月より先に遷移しようとする場合、ブラウザのアラートが表示される
- spec/models/consultation_schedule_spec.rb
visit_dateが6ヶ月先以降の場合にカスタムバリデーションが機能してinvalidになるか
