### PR TITLE
【Feature】1日の服薬回数を登録したことによる薬自動減算機能の修正

### DIFF
--- a/lib/tasks/medicine_stock.rake
+++ b/lib/tasks/medicine_stock.rake
@@ -8,7 +8,7 @@ namespace :medicine_stock do
 
     UserMedicine.has_stock.find_each do |user_medicine|
       before_stock = user_medicine.current_stock
-      new_stock = user_medicine.current_stock - user_medicine.dosage_per_time
+      new_stock = user_medicine.current_stock - user_medicine.daily_dosage
 
       if user_medicine.update(current_stock: [ new_stock, 0 ].max)
         success_count += 1

--- a/spec/factories/user_medicines.rb
+++ b/spec/factories/user_medicines.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :user_medicine do
     dosage_per_time { 1 }
+    times_per_day { 2 }
     prescribed_amount { 30 }
     date_of_prescription { Date.current }
     sequence(:uuid) { SecureRandom.uuid }


### PR DESCRIPTION
### 概要

issue [#201]
1日の服薬回数カラムを追加したことによる薬自動減算機能のロジックを修正しました。

### 作業内容
- lib/tasks/medicine_stock.rake
`user_medicine.daily_dosage`でその薬の1日の服薬量を取得

`docker compose exec web bundle exec rake medicine_stock:reduce_medicine_stock`を実行して1日の服薬量分在庫量が減ることを確認

### 機能追加理由

薬は飲み忘れないことを前提にして毎日在庫量を減らしており、1日の服薬量はまとめて1回で減らすようにしています。