### PR TITLE
【feature】1日の服薬回数追加による予想在庫表示の修正

### DIFF
--- a/app/views/home/_calendar.html.erb
+++ b/app/views/home/_calendar.html.erb
@@ -14,7 +14,7 @@
       </button>
     <% end %>
 
-    <span class="font-bold text-lg"><%= @start_date.strftime('%Y年%m月') %></span>
+    <span class="font-bold text-lg"><%= @start_date.strftime("%Y年%m月") %></span>
 
     <% next_month = @start_date + 1.month %>
     <% max_date = Date.current.beginning_of_month + 6.months %>
@@ -33,12 +33,12 @@
   <%= month_calendar(start_date: @start_date) do |date| %>
     <%= link_to date.day, home_path(date: date), data: { turbo_frame: "stock_modal" } %>
 
-    <!-- 薬の残り錠数表示 -->
+    <!-- 薬の在庫切れ予定日表示 -->
     <% medicines_with_stock.each do |medicine| %>
-      <% display_stock = medicine.display_stock_on(date) %>
-      <% if display_stock.present? %>
+      <% display_message = medicine.display_stock_on(date) %>
+      <% if display_message.present? %>
         <span class="block text-xs text-error leading-tight">
-          <%= medicine.medicine.name %><%= display_stock %>錠
+          <%= medicine.medicine.name %> <%= display_message %>
         </span>
       <% end %>
     <% end %>

--- a/spec/system/home/calendars_spec.rb
+++ b/spec/system/home/calendars_spec.rb
@@ -62,13 +62,13 @@ RSpec.describe "カレンダー表示", type: :system do
 
     context "カレンダー上の表示" do
       before do
-        create(:user_medicine, medicine: medicine2, prescribed_amount: 12, date_of_prescription: Date.yesterday, dosage_per_time: 1, current_stock: 11, user: user)
+        create(:user_medicine, medicine: medicine2, prescribed_amount: 2, date_of_prescription: Date.yesterday, dosage_per_time: 1, times_per_day: 1, current_stock: 1, user: user)
         create(:consultation_schedule, user: user, hospital: hospital, visit_date: Date.current)
         page.driver.browser.manage.window.resize_to(1200, 1000)
         visit home_path
       end
-      it "残り10錠の表示がある" do
-        expect(page).to have_content("テスト薬B10錠")
+      it "在庫切れ表示がある" do
+        expect(page).to have_content("テスト薬B 在庫切れ予定")
       end
 
       it "通院予定の表示がある" do


### PR DESCRIPTION
### 概要

issue [# 202]
1日の服薬回数カラムの追加による予想在庫表示の修正をしました。
カレンダー上の「残り⚪︎錠」の表示をなくして、「在庫切れ予定日」を表示しました。

### 作業内容
**予想在庫表示の修正**
- app/models/user_medicine.rb
1日の服薬量の`daily_dosage`を使ってロジックを修正

**在庫切れ予定日表示**
- app/models/user_medicine.rb
  - 在庫切れの日を計算する`stock_out_date`メソッドを定義
  - 在庫切れの日があれば「在庫切れ」と表示する`display_stock_on`メソッドを定義
- app/views/home/_calendar.html.erb
在庫切れの薬があれば`display_stock_on`を呼び出して表示する記述

**テスト**
- spec/system/home/calendars_spec.rb
カレンダー上に在庫切れ表示があるテスト

### 機能追加理由
1日の服薬回数カラムを追加したことにより予想在庫表示のロジックを変更する必要があったので実装しました。
残り⚪︎錠の表示では一貫性がなく、分かりにくかったので在庫が0になる日を統一で表示することにしました。今日の在庫量はカレンダーの上の一覧で見られるため、こちらの実装の方が分かりやすいと考えました。