### PR TITLE
【Feature】Notificationsテーブルを作成

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -4,6 +4,5 @@ class Notification < ApplicationRecord
   enum notification_type: { medicine_stock: "medicine_stock", consultation_reminder: "consultation_reminder" }
 
   validates :notification_type, presence: true, uniqueness: { scope: :user_id }
-  validates :enabled
   validates :days_before, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 7 }
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,9 @@
+class Notification < ApplicationRecord
+  belongs_to :user
+
+  enum notification_type: { medicine_stock: "medicine_stock", consultation_reminder: "consultation_reminder" }
+
+  validates :notification_type, presence: true, uniqueness: { scope: :user_id }
+  validates :enabled
+  validates :days_before, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 7 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
   has_many :medicines, dependent: :destroy
   has_many :hospitals, dependent: :destroy
   has_many :consultation_schedules, dependent: :destroy
+  has_many :notifications, dependent: :destroy
 
   # URLでuuidを使用するための設定
   def to_param

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,9 @@ class User < ApplicationRecord
   has_many :consultation_schedules, dependent: :destroy
   has_many :notifications, dependent: :destroy
 
+  # ユーザー作成後に通知設定を自動作成
+  after_create :create_default_notifications
+
   # URLでuuidを使用するための設定
   def to_param
     uuid
@@ -25,5 +28,23 @@ class User < ApplicationRecord
       user.name = auth.info.name
       user.line_user_id = auth.uid if auth.provider == "line"
     end
+  end
+
+  private
+
+  def create_default_notifications
+    # 薬の在庫通知を作成
+    notifications.create!(
+      notification_type: "medicine_stock",
+      enabled: false,
+      days_before: 5
+    )
+
+    # 通院予定通知を作成
+    notifications.create!(
+      notification_type: "consultation_reminder",
+      enabled: false,
+      days_before: 1
+    )
   end
 end

--- a/db/migrate/20260208232711_create_notifications.rb
+++ b/db/migrate/20260208232711_create_notifications.rb
@@ -1,0 +1,14 @@
+class CreateNotifications < ActiveRecord::Migration[7.2]
+  def change
+    create_table :notifications do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :notification_type, null: false
+      t.boolean :enabled, default: false, null: false
+      t.integer :days_before, null: false, default: 1
+
+      t.timestamps
+    end
+
+    add_index :notifications, [:user_id, :notification_type], unique: true
+  end
+end

--- a/db/migrate/20260208232711_create_notifications.rb
+++ b/db/migrate/20260208232711_create_notifications.rb
@@ -9,6 +9,6 @@ class CreateNotifications < ActiveRecord::Migration[7.2]
       t.timestamps
     end
 
-    add_index :notifications, [:user_id, :notification_type], unique: true
+    add_index :notifications, [ :user_id, :notification_type ], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_08_033939) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_08_232711) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,6 +56,17 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_08_033939) do
     t.index ["user_id"], name: "index_medicines_on_user_id"
   end
 
+  create_table "notifications", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "notification_type", null: false
+    t.boolean "enabled", default: false, null: false
+    t.integer "days_before", default: 1, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "notification_type"], name: "index_notifications_on_user_id_and_notification_type", unique: true
+    t.index ["user_id"], name: "index_notifications_on_user_id"
+  end
+
   create_table "user_medicines", force: :cascade do |t|
     t.integer "prescribed_amount", null: false
     t.integer "current_stock", default: 0, null: false
@@ -97,6 +108,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_08_033939) do
   add_foreign_key "hospital_schedules", "hospitals"
   add_foreign_key "hospitals", "users"
   add_foreign_key "medicines", "users"
+  add_foreign_key "notifications", "users"
   add_foreign_key "user_medicines", "medicines"
   add_foreign_key "user_medicines", "users"
 end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :notification do
+    notification_type { :medicine_stock }
+    enable { true }
+    days_before { 1 }
+    association :user
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -100,4 +100,14 @@ RSpec.describe User, type: :model do
       expect(association.options[:dependent]).to eq :destroy
     end
   end
+
+  describe "calback" do
+    it "ユーザー作成時にNotificationsが自動作成されること" do
+      user = create(:user)
+      user.reload
+
+      expect(user.notifications).to be_present
+      expect(Notification.count).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
### 概要

issue [# 196]
通知のNotificationsテーブルを作成、モデルファイルにバリデーションとアソシエーションを定義し、User作成時に同時にNotificationsレコードを作成する実装をしました。

### 作業内容

**機能追加**
1. マイグレーションファイル作成
  - `enabled`カラムはデフォルトでfalseに設定
  - `days_before`カラムのデフォルト値を1に設定
2. app/models/notification.rb
- enum
  - notification_typeは薬在庫通知の`medicine_stock`と通院予定日通知の`consultation_reminder`をenumに設定
- バリデーション
  - 1ユーザーは在庫通知（通院予定日通知）をするしないのどちらか1つのレコードしか持たないので、`notification_type`と`user_id`の複合ユニークを設定
  - 何日前に通知するかの`days_before`は0から7の範囲に限定
- アソシエーション
  - UsersとNotificationsは1対他
3. app/models/user.rb
- アソシエーション
  - １つのユーザーは複数の通知設定を持つ
- after_callback
  - ユーザー作成後に通知設定を自動作成する記述
  
**テスト**
- spec/factories/notifications.rb
  - NotificationsのFactoryBotを作成
- spec/models/user_spec.rb
  - ユーザー作成時にNotificationsが自動作成されること
### 機能追加理由

通知を管理するテーブルを作成することで通知一覧画面で管理しやすくしました。
