### PR TITLE
【Feature】通院予定日を知らせるLINE通知を実装

### DIFF
--- a/.github/workflows/notify_consultation_task.yml
+++ b/.github/workflows/notify_consultation_task.yml
@@ -1,0 +1,40 @@
+name: Notify Medicine Task
+
+on:
+  schedule:
+    # 9:00に実行
+    - cron: '0 0 * * *'
+  workflow_dispatch: # 手動実行も可能にする
+  push:
+    branches:
+      - feature/consultation_reminderrake # 現在の作業ブランチ
+      - main  # main ブランチでも動作確認
+
+jobs:
+  run-task:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3.10
+          bundler-cache: true
+
+      - name: Install dependencies
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Run notify consultation reminder task
+        env:
+          RAILS_ENV: production
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+        run: |
+          bundle exec rake consultation_notification:send_notification
+
+      - name: Notify on failure
+        if: failure()
+        run: echo "Notify Consultation Task failed. Please check the logs."

--- a/.github/workflows/notify_medicine_task.yml
+++ b/.github/workflows/notify_medicine_task.yml
@@ -6,9 +6,9 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch: # 手動実行も可能にする
   push:
-    branches:
-      - feature/medicine_stock_rake # 現在の作業ブランチ
-      - main  # main ブランチでも動作確認
+    # branches:
+    #   - feature/medicine_stock_rake # 現在の作業ブランチ
+    #   - main  # main ブランチでも動作確認
 
 jobs:
   run-task:

--- a/app/services/consultation_notification_service.rb
+++ b/app/services/consultation_notification_service.rb
@@ -52,7 +52,7 @@ class ConsultationNotificationService
     # プッシュメッセージリクエストを作成
     push_request = Line::Bot::V2::MessagingApi::PushMessageRequest.new(
       to: line_user_id,
-      messages: [message],
+      messages: [ message ],
     )
     begin
       response = LINE_BOT_CLIENT.push_message(push_message_request: push_request)

--- a/app/services/consultation_notification_service.rb
+++ b/app/services/consultation_notification_service.rb
@@ -13,7 +13,7 @@ class ConsultationNotificationService
 
   # 通知を送る
   def self.notify_consultation_schedules(user)
-    user.consultation_schedules.each do |consultaiton_schedule|
+    user.consultation_schedules.each do |consultation_schedule|
       next unless should_notify?(consultation_schedule)
 
       send_line_notification(consultation_schedule)

--- a/app/services/consultation_notification_service.rb
+++ b/app/services/consultation_notification_service.rb
@@ -1,0 +1,64 @@
+require "line/bot"
+
+class ConsultationNotificationService
+  # LINE通知を送るユーザー
+  def self.notify_users
+    User.joins(:notifications)
+        .includes(:consultation_schedules, :notifications)
+        .merge(Notification.active.consultation_reminder)
+        .find_each do |user|
+      notify_consultation_schedules(user)
+    end
+  end
+
+  # 通知を送る
+  def self.notify_consultation_schedules(user)
+    user.consultation_schedules.each do |consultaiton_schedule|
+      next unless should_notify?(consultation_schedule)
+
+      send_line_notification(consultation_schedule)
+    end
+  end
+
+  # 今日通知を送るかどうか
+  def self.should_notify?(consultation_schedule)
+    # ユーザーの在庫通知設定を取得
+    notification = consultation_schedule.user.notifications
+                                        .find_by(notification_type: :consultation_reminder, enabled: true)
+    return false if notification.blank?
+
+    # 通院予定日からdays_before日引いた日が今日かどうか判定
+    (consultation_schedule.visit_date - notification.days_before.days) == Date.current
+  end
+
+  # 通知の内容
+  def self.send_line_notification(consultation_schedule)
+    line_user_id = consultation_schedule.user.line_user_id
+    return unless line_user_id.present?
+
+    notification = consultation_schedule.user.notifications
+                                        .find_by(notification_type: :consultation_reminder, enabled: true)
+
+    hospital_name = consultation_schedule.hospital.name
+    days = notification.days_before
+
+    message = Line::Bot::V2::MessagingApi::TextMessage.new(
+      type: "text",
+      text: "【通院予定日の通知】\n" \
+            "#{hospital_name}への通院日は#{days}日後やで〜。\n" \
+            "忘れたあかんで〜。",
+    )
+
+    # プッシュメッセージリクエストを作成
+    push_request = Line::Bot::V2::MessagingApi::PushMessageRequest.new(
+      to: line_user_id,
+      messages: [message],
+    )
+    begin
+      response = LINE_BOT_CLIENT.push_message(push_message_request: push_request)
+      true
+    rescue => e
+      false
+    end
+  end
+end

--- a/app/services/medicine_notification_service.rb
+++ b/app/services/medicine_notification_service.rb
@@ -48,7 +48,7 @@ class MedicineNotificationService
     message = Line::Bot::V2::MessagingApi::TextMessage.new(
       type: "text",
       text: "【お薬の在庫通知】\n" \
-            "#{medicine_name}の在庫があと#{days}日分やで〜。】\n"
+            "#{medicine_name}の在庫があと#{days}日分やで〜。】\n" \
             "忘れんうちに薬もらいに行きやぁ〜。",
     )
 

--- a/app/services/medicine_notification_service.rb
+++ b/app/services/medicine_notification_service.rb
@@ -1,12 +1,6 @@
 require "line/bot"
 
 class MedicineNotificationService
-  def self.client
-    @client ||= Line::Bot::V2::MessagingApi::ApiClient.new(
-      channel_access_token: Rails.application.credentials.dig(:line, :messaging_channel_access_token),
-    )
-  end
-
   # LINE通知を送るユーザー
   def self.notify_users
     User.joins(:notifications)
@@ -63,7 +57,7 @@ class MedicineNotificationService
       messages: [ message ],
     )
     begin
-      response = client.push_message(push_message_request: push_request)
+      response = LINE_BOT_CLIENT.push_message(push_message_request: push_request)
       true
     rescue => e
       false

--- a/app/services/medicine_notification_service.rb
+++ b/app/services/medicine_notification_service.rb
@@ -48,7 +48,8 @@ class MedicineNotificationService
     message = Line::Bot::V2::MessagingApi::TextMessage.new(
       type: "text",
       text: "【お薬の在庫通知】\n" \
-            "#{medicine_name}の在庫があと#{days}日分となりました。",
+            "#{medicine_name}の在庫があと#{days}日分やで〜。】\n"
+            "忘れんうちに薬もらいに行きやぁ〜。",
     )
 
     # プッシュメッセージリクエストを作成

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -8,6 +8,6 @@ every 1.day, at: "0:00 am" do
   rake "medicine_stock:reduce_medicine_stock"
 end
 
-every 1.day, at: "9:00" do
+every 1.day, at: "9:00 am" do
   rake "medicine_notification:send_notification"
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -10,4 +10,5 @@ end
 
 every 1.day, at: "9:00 am" do
   rake "medicine_notification:send_notification"
+  rake "consultation_notification:send_notification"
 end

--- a/lib/tasks/consultation_notification.rake
+++ b/lib/tasks/consultation_notification.rake
@@ -1,0 +1,10 @@
+namespace :consultation_notification do
+  desc "通院予定通知を送信する"
+  task send_notification: :environment do
+    puts "通院予定通知の送信を開始します..."
+
+    ConsultationNotificationService.notify_users
+
+    puts "通院予定通知の送信が完了しました。"
+  end
+end


### PR DESCRIPTION
### 概要

isue [#199]
通院予定日が通知を設定した日になったらLINEで通知する機能を実装しました。

### 作業内容
**通知日かどうか判定するロジック**
- app/services/consultation_notification_service.rb
LINE通知を送るユーザー、今日通知を送るかどうかのロジックや通知の内容を記述

**定期実行**
開発環境ではwheneverを使ったcronで実行する。
1. lib/tasks/consultation_notification.rake
ConsultationNotificationServiceを実行するタスクを作成
2. config/schedule.rb
上記のタスクを毎日am9:00に実行する記述

本番環境ではGithubActionsで行う。

3. .github/workflows/notify_consultation_task.yml
毎日9時にconsultation_notification:send_notificationを実行する記述

### 機能追加理由

通院予定日をリマインドする機能があれば予定を忘れにくいため実装しました。
