### PR TITLE
【Feature】外部認証のテスト

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -23,6 +23,12 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
   end
 
+  # 認証失敗時
+  def failure
+    provider = request.env["omniauth.error.strategy"]&.name || "unknown"
+    redirect_to root_path, alert: "#{provider_name(provider)}認証に失敗しました"
+  end
+
   private
 
   # LINE以外でログインしたユーザーのLINE連携処理
@@ -57,11 +63,5 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       session["devise.#{provider}_data"] = request.env["omniauth.auth"].except(:extra)
       redirect_to new_user_registration_url, alert: @user.errors.full_messages.join("\n")
     end
-  end
-
-  # 認証失敗時
-  def failure
-    provider = request.env["omniauth.error.strategy"]&.name || "unknown"
-    redirect_to root_path, alert: "#{provider_name(provider)}認証に失敗しました"
   end
 end

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -22,7 +22,7 @@
             <span class="inline-block mr-2">LINE通知設定</span>
           <% end %>
         <% else %>
-          <%= link_to line_connections_required_path, class: "btn btn-secondary flex-1 text-center" do %>
+          <%= link_to line_connections_path, class: "btn btn-secondary flex-1 text-center" do %>
             <span class="inline-block mr-2">LINE通知設定</span>
           <% end %>
         <% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -296,17 +296,15 @@ Devise.setup do |config|
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
 
-  unless Rails.env.test?
-    config.omniauth :google_oauth2,
-      Rails.application.credentials.dig(:google, :google_client_id),
-      Rails.application.credentials.dig(:google, :google_client_secret),
-      scope: "email,profile,openid",
-      name: :google_oauth2
+  config.omniauth :google_oauth2,
+    Rails.application.credentials.dig(:google, :google_client_id),
+    Rails.application.credentials.dig(:google, :google_client_secret),
+    scope: "email,profile,openid",
+    name: :google_oauth2
 
-    config.omniauth :line,
-      Rails.application.credentials.dig(:line, :channel_id),
-      Rails.application.credentials.dig(:line, :channel_secret)
-  end
+  config.omniauth :line,
+    Rails.application.credentials.dig(:line, :channel_id),
+    Rails.application.credentials.dig(:line, :channel_secret)
 
   # ==> Hotwire/Turbo configuration
   # When using Devise with Hotwire/Turbo, the http status for error responses

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -54,9 +54,9 @@ ja:
         logout_confirmation: "ログアウトしますか？"
         cancel_confirmation: 'アカウントを本当に削除しますか？'
     sessions:
-      signed_in: 'ログインしました。'
-      signed_out: 'ログアウトしました。'
-      already_signed_out: '既にログアウト済みです。'
+      signed_in: 'ログインしました'
+      signed_out: 'ログアウトしました'
+      already_signed_out: '既にログアウト済みです'
     unlocks:
       send_instructions: 'アカウントの凍結解除方法を数分以内にメールでご連絡します。'
       send_paranoid_instructions: 'アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,5 +35,5 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "static_pages#top"
   get "home", to: "home#index"
-  get "line_connections/required", to: "line_connections#required"
+  get "line_connections", to: "line_connections#required"
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,5 +4,15 @@ FactoryBot.define do
     sequence(:email) { |n| "user_#{n}@example.com" }
     password { "password" }
     password_confirmation { "password" }
+    # LINE連携済みユーザー
+    trait :with_line do
+      sequence(:line_user_id) { |n| "line_user_id_#{n}" }
+    end
+
+    # LINEでログインしたユーザー
+    trait :line_login do
+      sequence(:line_user_id) { |n| "line_uid_#{n}" }
+      email { "#{line_user_id}@line.example.com" }
+    end
   end
 end

--- a/spec/support/omniauth_helper.rb
+++ b/spec/support/omniauth_helper.rb
@@ -1,0 +1,32 @@
+OmniAuth.config.test_mode = true
+
+module OmniauthMocks
+  def line_mock(uid: '12345')
+    OmniAuth.config.mock_auth[:line] = OmniAuth::AuthHash.new({
+  provider: "line",
+  uid: uid,
+  info: {
+    name: "LINE太郎"
+  },
+  credentials: {
+    token: "mock_token"
+  }
+})
+  end
+
+  def line_mock_failure
+    OmniAuth.config.mock_auth[:line] = :invalid_credentials
+  end
+end
+
+RSpec.configure do |config|
+  config.include OmniauthMocks
+
+  config.before(:each) do
+    OmniAuth.config.test_mode = true
+  end
+
+  config.after(:each) do
+    OmniAuth.config.mock_auth[:line] = nil
+  end
+end

--- a/spec/support/omniauth_helper.rb
+++ b/spec/support/omniauth_helper.rb
@@ -18,18 +18,16 @@ module OmniauthMocks
   end
 
   # Googleのモック
-  def google_mock
+  def google_mock(uid: "67890")
     OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
       provider: "google_oauth2",
-      uid: "67890",
+      uid: uid,
       info: {
         name: "Google テストユーザー",
-        email: "test@example.com",
-        image: "https://example.com/google_avatar.jpg"
+        email: "test@example.com"
       },
       credentials: {
-        token: "mock_google_token",
-        expires_at: Time.now + 1.week
+        token: "mock_google_token"
       }
     })
   end

--- a/spec/support/omniauth_helper.rb
+++ b/spec/support/omniauth_helper.rb
@@ -1,32 +1,44 @@
-OmniAuth.config.test_mode = true
-
 module OmniauthMocks
-  def line_mock(uid: '12345')
+  # LINEのモック
+  def line_mock(uid: "12345")
     OmniAuth.config.mock_auth[:line] = OmniAuth::AuthHash.new({
-  provider: "line",
-  uid: uid,
-  info: {
-    name: "LINE太郎"
-  },
-  credentials: {
-    token: "mock_token"
-  }
-})
+      provider: "line",
+      uid: uid,
+      info: {
+        name: "LINE太郎"
+      },
+      credentials: {
+        token: "mock_token"
+      }
+    })
   end
 
   def line_mock_failure
     OmniAuth.config.mock_auth[:line] = :invalid_credentials
   end
+
+  # Googleのモック
+  def google_mock
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
+      provider: "google_oauth2",
+      uid: "67890",
+      info: {
+        name: "Google テストユーザー",
+        email: "test@example.com",
+        image: "https://example.com/google_avatar.jpg"
+      },
+      credentials: {
+        token: "mock_google_token",
+        expires_at: Time.now + 1.week
+      }
+    })
+  end
+
+  def google_mock_failure
+    OmniAuth.config.mock_auth[:google_oauth2] = :invalid_credentials
+  end
 end
 
 RSpec.configure do |config|
-  config.include OmniauthMocks
-
-  config.before(:each) do
-    OmniAuth.config.test_mode = true
-  end
-
-  config.after(:each) do
-    OmniAuth.config.mock_auth[:line] = nil
-  end
+  config.include OmniauthMocks, type: :system
 end

--- a/spec/system/users/line_login_spec.rb
+++ b/spec/system/users/line_login_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe "LINEログイン", type: :system do
+  describe 'LINEログイン機能' do
+    context '新規ユーザーの場合' do
+      it 'LINEでログインボタンから新規登録できる' do
+        line_mock
+
+        visit new_user_registration_path
+        click_button 'LINEでログイン'
+
+        expect(page).to have_content 'LINE アカウントでログインしました'
+        expect(current_path).to eq home_path
+        expect(User.last.line_user_id).to eq '12345'
+      end
+    end
+
+    context '既存のLINEユーザーの場合' do
+      let!(:user) { create(:user, :line_login) }
+
+      it '既存アカウントでログインできる' do
+        line_mock
+
+        visit new_user_session_path
+
+        click_button 'LINEでログイン'
+
+        expect(page).to have_content 'LINE アカウントでログインしました'
+        expect(current_path).to eq home_path
+      end
+    end
+
+    context 'LINE認証に失敗した場合' do
+      it 'エラーメッセージが表示される' do
+        line_mock_failure
+
+        visit new_user_registration_path
+        click_button 'LINEでログイン'
+
+        expect(page).to have_content 'LINE認証に失敗しました'
+        expect(current_path).to eq root_path
+      end
+    end
+  end
+
+  describe 'LINE連携機能' do
+    let!(:user) { create(:user) }
+
+    before do
+      sign_in user
+    end
+
+    context 'メール登録済みユーザーがLINE連携する場合' do
+      it 'LINE連携が成功する' do
+        line_mock
+
+        visit line_connections_path
+        click_button 'LINEと連携する'
+
+        expect(page).to have_content 'LINE連携が完了しました'
+        expect(current_path).to eq edit_notifications_path
+        expect(user.reload.line_user_id).to eq '12345'
+      end
+    end
+
+    context '既に他のユーザーが使用しているLINEアカウントの場合' do
+      let!(:other_user) { create(:user, :with_line, line_user_id: '12345') }
+
+      it 'エラーメッセージが表示される' do
+        line_mock
+
+        visit line_connections_path
+        click_button 'LINEと連携する'
+
+        expect(page).to have_content 'このLINEアカウントは既に他のユーザーに連携されています'
+        expect(current_path).to eq mypage_path
+        expect(user.reload.line_user_id).to be_nil
+      end
+    end
+  end
+end

--- a/spec/system/users/line_login_spec.rb
+++ b/spec/system/users/line_login_spec.rb
@@ -1,6 +1,14 @@
 require "rails_helper"
 
-RSpec.describe "LINEログイン", type: :system do
+RSpec.describe 'Users::OmniauthCallbacks', type: :system do
+  before do
+    OmniAuth.config.test_mode = true
+  end
+
+  after do
+    OmniAuth.config.test_mode = false
+  end
+
   describe 'LINEログイン機能' do
     context '新規ユーザーの場合' do
       it 'LINEでログインボタンから新規登録できる' do
@@ -75,6 +83,47 @@ RSpec.describe "LINEログイン", type: :system do
         expect(page).to have_content 'このLINEアカウントは既に他のユーザーに連携されています'
         expect(current_path).to eq mypage_path
         expect(user.reload.line_user_id).to be_nil
+      end
+    end
+  end
+
+  describe 'Googleログイン機能' do
+    context '新規ユーザーの場合' do
+      it 'Googleでログインボタンから新規登録できる' do
+        line_mock
+
+        visit new_user_registration_path
+        click_button 'Googleログイン'
+
+        expect(page).to have_content 'Google アカウントでログインしました'
+        expect(current_path).to eq home_path
+      end
+    end
+
+    context '既存のGoogleユーザーの場合' do
+      let!(:user) { create(:user, :line_login) }
+
+      it '既存アカウントでログインできる' do
+        line_mock
+
+        visit new_user_session_path
+
+        click_button 'Googleログイン'
+
+        expect(page).to have_content 'Google アカウントでログインしました'
+        expect(current_path).to eq home_path
+      end
+    end
+
+    context 'Google認証に失敗した場合' do
+      it 'エラーメッセージが表示される' do
+        google_mock_failure
+
+        visit new_user_registration_path
+        click_button 'Googleログイン'
+
+        expect(page).to have_content 'Google認証に失敗しました'
+        expect(current_path).to eq root_path
       end
     end
   end

--- a/spec/system/users/line_login_spec.rb
+++ b/spec/system/users/line_login_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe 'Users::OmniauthCallbacks', type: :system do
+RSpec.describe "Users::OmniauthCallbacks", type: :system do
   before do
     OmniAuth.config.test_mode = true
   end
@@ -9,120 +9,120 @@ RSpec.describe 'Users::OmniauthCallbacks', type: :system do
     OmniAuth.config.test_mode = false
   end
 
-  describe 'LINEログイン機能' do
-    context '新規ユーザーの場合' do
-      it 'LINEでログインボタンから新規登録できる' do
+  describe "LINEログイン機能" do
+    context "新規ユーザーの場合" do
+      it "LINEでログインボタンから新規登録できる" do
         line_mock
 
         visit new_user_registration_path
-        click_button 'LINEでログイン'
+        click_button "LINEでログイン"
 
-        expect(page).to have_content 'LINE アカウントでログインしました'
+        expect(page).to have_content "LINE アカウントでログインしました"
         expect(current_path).to eq home_path
-        expect(User.last.line_user_id).to eq '12345'
+        expect(User.last.line_user_id).to eq "12345"
       end
     end
 
-    context '既存のLINEユーザーの場合' do
+    context "既存のLINEユーザーの場合" do
       let!(:user) { create(:user, :line_login) }
 
-      it '既存アカウントでログインできる' do
+      it "既存アカウントでログインできる" do
         line_mock
 
         visit new_user_session_path
 
-        click_button 'LINEでログイン'
+        click_button "LINEでログイン"
 
-        expect(page).to have_content 'LINE アカウントでログインしました'
+        expect(page).to have_content "LINE アカウントでログインしました"
         expect(current_path).to eq home_path
       end
     end
 
-    context 'LINE認証に失敗した場合' do
-      it 'エラーメッセージが表示される' do
+    context "LINE認証に失敗した場合" do
+      it "エラーメッセージが表示される" do
         line_mock_failure
 
         visit new_user_registration_path
-        click_button 'LINEでログイン'
+        click_button "LINEでログイン"
 
-        expect(page).to have_content 'LINE認証に失敗しました'
+        expect(page).to have_content "LINE認証に失敗しました"
         expect(current_path).to eq root_path
       end
     end
   end
 
-  describe 'LINE連携機能' do
+  describe "LINE連携機能" do
     let!(:user) { create(:user) }
 
     before do
       sign_in user
     end
 
-    context 'メール登録済みユーザーがLINE連携する場合' do
-      it 'LINE連携が成功する' do
+    context "メール登録済みユーザーがLINE連携する場合" do
+      it "LINE連携が成功する" do
         line_mock
 
         visit line_connections_path
-        click_button 'LINEと連携する'
+        click_button "LINEと連携する"
 
-        expect(page).to have_content 'LINE連携が完了しました'
+        expect(page).to have_content "LINE連携が完了しました"
         expect(current_path).to eq edit_notifications_path
-        expect(user.reload.line_user_id).to eq '12345'
+        expect(user.reload.line_user_id).to eq "12345"
       end
     end
 
-    context '既に他のユーザーが使用しているLINEアカウントの場合' do
-      let!(:other_user) { create(:user, :with_line, line_user_id: '12345') }
+    context "既に他のユーザーが使用しているLINEアカウントの場合" do
+      let!(:other_user) { create(:user, :with_line, line_user_id: "12345") }
 
-      it 'エラーメッセージが表示される' do
+      it "エラーメッセージが表示される" do
         line_mock
 
         visit line_connections_path
-        click_button 'LINEと連携する'
+        click_button "LINEと連携する"
 
-        expect(page).to have_content 'このLINEアカウントは既に他のユーザーに連携されています'
+        expect(page).to have_content "このLINEアカウントは既に他のユーザーに連携されています"
         expect(current_path).to eq mypage_path
         expect(user.reload.line_user_id).to be_nil
       end
     end
   end
 
-  describe 'Googleログイン機能' do
-    context '新規ユーザーの場合' do
-      it 'Googleでログインボタンから新規登録できる' do
+  describe "Googleログイン機能" do
+    context "新規ユーザーの場合" do
+      it "Googleでログインボタンから新規登録できる" do
         line_mock
 
         visit new_user_registration_path
-        click_button 'Googleログイン'
+        click_button "Googleログイン"
 
-        expect(page).to have_content 'Google アカウントでログインしました'
+        expect(page).to have_content "Google アカウントでログインしました"
         expect(current_path).to eq home_path
       end
     end
 
-    context '既存のGoogleユーザーの場合' do
+    context "既存のGoogleユーザーの場合" do
       let!(:user) { create(:user, :line_login) }
 
-      it '既存アカウントでログインできる' do
+      it "既存アカウントでログインできる" do
         line_mock
 
         visit new_user_session_path
 
-        click_button 'Googleログイン'
+        click_button "Googleログイン"
 
-        expect(page).to have_content 'Google アカウントでログインしました'
+        expect(page).to have_content "Google アカウントでログインしました"
         expect(current_path).to eq home_path
       end
     end
 
-    context 'Google認証に失敗した場合' do
-      it 'エラーメッセージが表示される' do
+    context "Google認証に失敗した場合" do
+      it "エラーメッセージが表示される" do
         google_mock_failure
 
         visit new_user_registration_path
-        click_button 'Googleログイン'
+        click_button "Googleログイン"
 
-        expect(page).to have_content 'Google認証に失敗しました'
+        expect(page).to have_content "Google認証に失敗しました"
         expect(current_path).to eq root_path
       end
     end

--- a/spec/system/users/omniauth_callbacks_spec.rb
+++ b/spec/system/users/omniauth_callbacks_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Users::OmniauthCallbacks", type: :system do
 
   describe "LINEログイン機能" do
     context "新規ユーザーの場合" do
-      it "LINEでログインボタンから新規登録できる" do
+      it "LINEで新規登録できる" do
         line_mock
 
         visit new_user_registration_path
@@ -23,10 +23,10 @@ RSpec.describe "Users::OmniauthCallbacks", type: :system do
       end
     end
 
-    context "既存のLINEユーザーの場合" do
+    context "新規登録済みのLINEユーザーの場合" do
       let!(:user) { create(:user, :line_login) }
 
-      it "既存アカウントでログインできる" do
+      it "登録済みのアカウントでログインできる" do
         line_mock
 
         visit new_user_session_path
@@ -58,7 +58,7 @@ RSpec.describe "Users::OmniauthCallbacks", type: :system do
       sign_in user
     end
 
-    context "メール登録済みユーザーがLINE連携する場合" do
+    context "LINEログイン以外でログインしたユーザーがLINE連携する場合" do
       it "LINE連携が成功する" do
         line_mock
 
@@ -89,7 +89,7 @@ RSpec.describe "Users::OmniauthCallbacks", type: :system do
 
   describe "Googleログイン機能" do
     context "新規ユーザーの場合" do
-      it "Googleでログインボタンから新規登録できる" do
+      it "Googleで新規登録できる" do
         line_mock
 
         visit new_user_registration_path
@@ -100,10 +100,10 @@ RSpec.describe "Users::OmniauthCallbacks", type: :system do
       end
     end
 
-    context "既存のGoogleユーザーの場合" do
+    context "登録済みのGoogleユーザーの場合" do
       let!(:user) { create(:user, :line_login) }
 
-      it "既存アカウントでログインできる" do
+      it "登録済みのアカウントでログインできる" do
         line_mock
 
         visit new_user_session_path

--- a/spec/system/users/sessions_spec.rb
+++ b/spec/system/users/sessions_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "UserSessions", type: :system do
         fill_in "メールアドレス", with: user.email
         fill_in "パスワード", with: "password"
         click_button "ログイン"
-        expect(page).to have_content ("ログインしました。")
+        expect(page).to have_content ("ログインしました")
         expect(current_path).to eq home_path
       end
     end
@@ -30,7 +30,7 @@ RSpec.describe "UserSessions", type: :system do
           click_link "ログアウト"
         end
 
-        expect(page).to have_content("ログアウトしました。")
+        expect(page).to have_content("ログアウトしました")
         expect(current_path).to eq root_path
       end
     end


### PR DESCRIPTION
### 概要

issue [#95]
LINEログイン、Googleログイン、LINE連携のテストを記述しました。

### 作業内容
- config/initializers/devise.rb
テスト環境でもcreentialsを参照するため、`unless Rails.env.test?`を外す
- spec/factories/users.rb
LINEでログインしたユーザーのFactoryBotを作成
- spec/support/omniauth_helper.rb
LINEとGoogleのモックを作成
- spec/support/omniauth_helper.rb
認証の流れをテスト

**LINEログイン**
- LINEでログインボタンから新規登録できる
- 登録済みのアカウントでログインできる
- LINE認証に失敗した場合、エラーメッセージが表示される

**LINE連携**
- LINEログイン以外でログインしたユーザーがLINE連携できる
- 既に他のユーザーが使用しているLINEアカウントの場合、エラーメッセージが表示される

**Googleログイン**
- Googleでログインボタンから新規登録できる
- 登録済みのアカウントでログインできる
- Google認証に失敗した場合、エラーメッセージが表示される

### 機能追加理由
認証のエラーを出して確認することが難しかったのでテストで確認しました。

### 備考
`docker compose exec web bundle exec rspec`が全て通過することを確認しました。