### PR TITLE
【Chore】薬関連画面のデザインをブラッシュアップ

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -9,7 +9,7 @@
   prefersdark: false; /* set as default dark mode (prefers-color-scheme:dark) */
   color-scheme: light;
 
-  --color-base-100: #F9E9D8; /* ページ背景 */
+  --color-base-100: #FCF7F0; /* ページ背景 */
   --color-base-200: #FDEDE9;  /* カード・フォーム */
   --color-base-300: #E0D8CF; /* 枠線、区切り */
   --color-base-content: #3D3A38;

--- a/app/controllers/user_medicines_controller.rb
+++ b/app/controllers/user_medicines_controller.rb
@@ -32,6 +32,7 @@ class UserMedicinesController < ApplicationController
     if @form.save
       redirect_to user_medicines_path, notice: "薬を登録しました"
     else
+      flash.now[:alert] = "お薬の登録に失敗しました"
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,4 +7,14 @@ module ApplicationHelper
     else "bg-blue-200 text-blue-800"
     end
   end
+
+  # 入力フォーム
+  def form_field_class(object, field_name)
+    base_class = "border rounded px-3 py-2 w-full"
+    if object.errors[field_name].any?
+      "#{base_class} border-red-500 border-2 bg-red-50"
+    else
+      "#{base_class} border-gray-300"
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,9 +8,19 @@ module ApplicationHelper
     end
   end
 
-  # 入力フォーム
+  # 入力フォーム(エラー箇所のフォームは赤になる)
   def form_field_class(object, field_name)
     base_class = "border rounded px-3 py-2 w-full"
+    if object.errors[field_name].any?
+      "#{base_class} border-red-500 border-2 bg-red-50"
+    else
+      "#{base_class} border-gray-300"
+    end
+  end
+
+  # date用の入力フォーム
+  def date_form_field_class(object, field_name)
+    base_class = "border rounded px-3 py-2"
     if object.errors[field_name].any?
       "#{base_class} border-red-500 border-2 bg-red-50"
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,8 +1,9 @@
 module ApplicationHelper
+  # フラッシュメッセージの背景色
   def flash_background_color(type)
     case type.to_sym
     when :notice, :success then "bg-green-200 text-green-800"
-    when :alert, :alert then "bg-red-200 text-red-800"
+    when :alert, :alert then "bg-red-300 text-red-800"
     else "bg-blue-200 text-blue-800"
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  def flash_background_color(type)
+    case type.to_sym
+    when :notice, :success then "bg-green-200 text-green-800"
+    when :alert, :alert then "bg-red-200 text-red-800"
+    else "bg-blue-200 text-blue-800"
+    end
+  end
 end

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    // 3秒後にフェードアウトして削除
+    setTimeout(() => {
+      this.element.style.transition = "opacity 0.5s ease-out"
+      this.element.style.opacity = "0"
+
+      // フェードアウトが完了したら要素を削除
+      setTimeout(() => {
+        this.element.remove()
+      }, 500)
+    }, 3000)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application"
 import AutocompleteController from "./autocomplete_controller"
 application.register("autocomplete", AutocompleteController)
 
+import FlashController from "./flash_controller"
+application.register("flash", FlashController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700&display=swap" rel="stylesheet">
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module"%>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,8 +1,11 @@
 <% if object.errors.any? %>
-  <div class="error-messages alert alert-danger">
-    <ul class="mb-0">
+  <div class="bg-red-200 border-2 border-red-300 rounded-lg p-4 mb-4">
+    <h3 class="text-red-700 font-bold text-lg mb-3 flex items-center">
+      ⚠️ 入力内容に誤りがあります
+    </h3>
+    <ul class="list-disc list-inside space-y-1">
       <% object.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+        <li class="text-red-600"><%= message %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,5 +1,7 @@
-<% flash.each do |message_type, message| %>
-  <div class="alert alert-<%= message_type %>">
-    <%= message %>
-  </div>
-<% end %>
+<div class="fixed top-4 left-1/2 transform -translate-x-1/2 z-50 w-full max-w-md px-4">
+  <% flash.each do |message_type, message| %>
+    <div class="<%= flash_background_color(message_type) %> px-6 py-4 rounded-lg shadow-lg mb-4 flash-message text-center" data-controller="flash">
+      <%= message %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="navbar bg-primary text-primary-content px-4">
+<header class="navbar bg-base-200 px-4">
   <!-- Hamburger -->
   <label for="drawer-menu" class="btn btn-ghost btn-sm drawer-button">
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"

--- a/app/views/user_medicines/_increment_stock_modal.html.erb
+++ b/app/views/user_medicines/_increment_stock_modal.html.erb
@@ -1,0 +1,23 @@
+<input type="checkbox" id="confirm-modal-<%= user_medicine.id %>" class="modal-toggle" />
+<div class="modal">
+  <div class="modal-box">
+    <h3 class="font-bold text-lg">飲み忘れの確認</h3>
+    <p class="py-4">
+      <%= user_medicine.medicine.name %> は現在残り <%= user_medicine.current_stock %> 錠です。<br>
+      1回分増やしますか?
+    </p>
+    <div class="modal-action">
+      <label for="confirm-modal-<%= user_medicine.id %>" class="btn">
+        キャンセル
+      </label>
+      <%= button_to "OK",
+                    increment_stock_user_medicine_path(user_medicine),
+                    method: :patch,
+                    form: { class: "inline" },
+                    class: "btn btn-primary" %>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="button">close</button>
+  </form>
+</div>

--- a/app/views/user_medicines/add_stock.html.erb
+++ b/app/views/user_medicines/add_stock.html.erb
@@ -60,7 +60,7 @@
               <%= f.text_field :prescribed_amount,
                                placeholder: "追加する数量を入力",
                                type: "number",
-                               class: "border border-gray-300 rounded px-3 py-2" %>
+                               class: form_field_class(f.object, :prescribed_amount) %>
               <span class="text-gray-700 whitespace-nowrap">錠</span>
             </div>
           </div>
@@ -68,7 +68,7 @@
           <div class="mb-4">
             <%= f.label :date_of_prescription, "処方日", class: "block text-sm font-bold mb-2" %>
             <%= f.date_field :date_of_prescription,
-                             class: "border border-gray-300 rounded px-3 py-2" %>
+                             class: form_field_class(f.object, :date_of_prescription) %>
           </div>
 
           <!-- 保存ボタン -->

--- a/app/views/user_medicines/add_stock.html.erb
+++ b/app/views/user_medicines/add_stock.html.erb
@@ -1,9 +1,33 @@
-<div class="container mx-auto px-4">
+<div class="container mx-auto px-4 mb-16">
   <div class="medicines-section max-w-4xl mx-auto mb-8">
     <div class="w-full">
-      <h1 class="font-bold text-4xl text-center mb-6">在庫追加</h1>
 
-      <div class="bg-white rounded-lg shadow p-6">
+    <!-- 薬一覧へのボタン-->
+     <div class="flex mt-2 mb-2">
+        <%= link_to user_medicine_path(@user_medicine), class: "link link-primary hover:link-hover" do %>
+          <i class="fa-solid fa-arrow-left fa-sm"></i>
+          <span class="ml-2">戻る</span>
+        <% end %>
+      </div>
+
+      <!-- タイトルと説明文 -->
+      <div class="text-center">
+        <h1 class="text-3xl text-center mb-2 mt-2" style="font-family: 'M PLUS Rounded 1c', sans-serif; font-weight: 500;">
+          <i class="fa-solid fa-pills" style="color: rgba(255, 136, 59, 1.00);"></i>在庫追加
+        </h1>
+        <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 max-w-2xl mx-auto mb-2">
+          <p class="text-blue-800 text-sm mb-2">
+            <i class="fa-solid fa-circle-info mr-2"></i>
+            <strong>処方された薬の数量を入力しましょう</strong>
+          </p>
+          <p class="text-blue-700 text-sm">
+            今回処方された数量を入力すると、現在の在庫に自動で追加されます
+          </p>
+        </div>
+      </div>
+
+     <!-- 在庫追加フォーム -->
+      <div class="bg-white rounded-lg shadow p-6 mb-8">
         <%= form_with(model: @stock_form,
                       url: update_stock_user_medicine_path(@user_medicine),
                       method: :patch) do |f| %>
@@ -54,9 +78,9 @@
                              class: "border border-gray-300 rounded px-3 py-2" %>
           </div>
 
-          <div class="flex gap-4">
-            <%= f.submit "在庫を追加する", class: "btn btn-primary flex-1" %>
-            <%= link_to "戻る", user_medicine_path(@user_medicine), class: "btn btn-neutral flex-1" %>
+          <!-- 保存ボタン -->
+          <div class="flex justify-center">
+            <%= f.submit "保存する", class: "btn btn-primary px-8" %>
           </div>
         <% end %>
       </div>

--- a/app/views/user_medicines/add_stock.html.erb
+++ b/app/views/user_medicines/add_stock.html.erb
@@ -68,7 +68,7 @@
           <div class="mb-4">
             <%= f.label :date_of_prescription, "処方日", class: "block text-sm font-bold mb-2" %>
             <%= f.date_field :date_of_prescription,
-                             class: form_field_class(f.object, :date_of_prescription) %>
+                             class: date_form_field_class(f.object, :date_of_prescription) %>
           </div>
 
           <!-- 保存ボタン -->

--- a/app/views/user_medicines/add_stock.html.erb
+++ b/app/views/user_medicines/add_stock.html.erb
@@ -1,5 +1,5 @@
 <div class="container mx-auto px-4 mb-16">
-  <div class="medicines-section max-w-4xl mx-auto mb-8">
+  <div class="medicines-section max-w-2xl mx-auto mb-8">
     <div class="w-full">
 
     <!-- 薬一覧へのボタン-->

--- a/app/views/user_medicines/add_stock.html.erb
+++ b/app/views/user_medicines/add_stock.html.erb
@@ -13,7 +13,7 @@
       <!-- タイトルと説明文 -->
       <div class="text-center">
         <h1 class="text-3xl text-center mb-2 mt-2" style="font-family: 'M PLUS Rounded 1c', sans-serif; font-weight: 500;">
-          <i class="fa-solid fa-pills" style="color: rgba(255, 136, 59, 1.00);"></i>在庫追加
+          <i class="fa-solid fa-pills" style="color: rgba(255, 136, 59, 1.00);"></i><%= @user_medicine.medicine.name %>の在庫追加
         </h1>
         <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 max-w-2xl mx-auto mb-2">
           <p class="text-blue-800 text-sm mb-2">
@@ -32,13 +32,6 @@
                       url: update_stock_user_medicine_path(@user_medicine),
                       method: :patch) do |f| %>
           <%= render "shared/error_messages", object: f.object %>
-
-          <div class="mb-4">
-            <label class="block text-sm font-bold mb-2">薬名</label>
-            <div class="bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-700">
-              <%= @user_medicine.medicine.name %>
-            </div>
-          </div>
 
           <div class="mb-4">
             <label class="block text-sm font-bold mb-2">1回の服薬量</label>

--- a/app/views/user_medicines/add_stock.html.erb
+++ b/app/views/user_medicines/add_stock.html.erb
@@ -4,9 +4,9 @@
 
     <!-- 薬一覧へのボタン-->
      <div class="flex mt-2 mb-2">
-        <%= link_to user_medicine_path(@user_medicine), class: "link link-primary hover:link-hover" do %>
+        <%= link_to user_medicine_path(@user_medicine), class: "text-gray-800 hover:text-red-500 inline-flex items-center gap-2 transition-colors duration-200" do %>
           <i class="fa-solid fa-arrow-left fa-sm"></i>
-          <span class="ml-2">戻る</span>
+          <span>戻る</span>
         <% end %>
       </div>
 

--- a/app/views/user_medicines/forgot_index.html.erb
+++ b/app/views/user_medicines/forgot_index.html.erb
@@ -1,7 +1,7 @@
 <div class="container mx-auto px-4 py-8">
   <h1 class="font-bold text-4xl text-center mb-6">飲み忘れ</h1>
   <div class="bg-white max-w-4xl mx-auto rounded-lg shadow mb-6">
-    <%if @medicines_with_stock.any? %>
+    <% if @medicines_with_stock.any? %>
       <% @medicines_with_stock.each do |user_medicine| %>
         <div class="flex items-center justify-between p-4 border-b hover:bg-gray-50 mb-4">
           <div class="flex-1">
@@ -10,13 +10,9 @@
             </div>
             <p class="text-gray-600">残り<%= user_medicine.current_stock %>錠</p>
           </div>
-            <%= button_to "飲み忘れ",
-                increment_stock_user_medicine_path(user_medicine),
-                method: :patch,
-                data: {
-                  turbo_confirm: "#{user_medicine.medicine.name}は現在残り#{user_medicine.current_stock}錠です。1回分増やしますか？"
-                },
-                class: "btn btn-secondary" %>
+          <label for="forgot-modal-<%= user_medicine.id %>" class="btn btn-secondary">
+            飲み忘れ
+          </label>
         </div>
       <% end %>
     <% else %>
@@ -24,3 +20,32 @@
     <% end %>
   </div>
 </div>
+
+<!-- モーダルの中身 -->
+<% if @medicines_with_stock.any? %>
+  <% @medicines_with_stock.each do |user_medicine| %>
+    <input type="checkbox" id="forgot-modal-<%= user_medicine.id %>" class="modal-toggle" />
+    <div class="modal">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg">飲み忘れの確認</h3>
+        <p class="py-4">
+          <%= user_medicine.medicine.name %>は現在残り<%= user_medicine.current_stock %>錠です。<br>
+          1回分増やしますか?
+        </p>
+        <div class="modal-action">
+          <!-- キャンセルボタン -->
+          <label for="forgot-modal-<%= user_medicine.id %>" class="btn">
+            キャンセル
+          </label>
+
+          <!-- 実行ボタン -->
+          <%= button_to "OK",
+              increment_stock_user_medicine_path(user_medicine),
+              method: :patch,
+              class: "btn btn-primary",
+              form: { onsubmit: "document.getElementById('forgot-modal-#{user_medicine.id}').checked = false;" } %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/user_medicines/forgot_index.html.erb
+++ b/app/views/user_medicines/forgot_index.html.erb
@@ -11,10 +11,13 @@
               </div>
               <p class="text-gray-600">残り<%= user_medicine.current_stock %>錠</p>
             </div>
-            <label for="forgot-modal-<%= user_medicine.id %>" class="btn btn-secondary">
+            <label for="confirm-modal-<%= user_medicine.id %>" class="btn btn-secondary">
               飲み忘れ
             </label>
           </div>
+
+          <!-- モーダルの中身 -->
+          <%= render "increment_stock_modal", user_medicine: user_medicine %>
         <% end %>
       <% else %>
         <p class="text-center py-8">現在、薬はありません</p>
@@ -22,32 +25,3 @@
     </div>
   </div>
 </div>
-
-<!-- モーダルの中身 -->
-<% if @medicines_with_stock.any? %>
-  <% @medicines_with_stock.each do |user_medicine| %>
-    <input type="checkbox" id="forgot-modal-<%= user_medicine.id %>" class="modal-toggle" />
-    <div class="modal">
-      <div class="modal-box">
-        <h3 class="font-bold text-lg">飲み忘れの確認</h3>
-        <p class="py-4">
-          <%= user_medicine.medicine.name %>は現在残り<%= user_medicine.current_stock %>錠です。<br>
-          1回分増やしますか?
-        </p>
-        <div class="modal-action">
-          <!-- キャンセルボタン -->
-          <label for="forgot-modal-<%= user_medicine.id %>" class="btn">
-            キャンセル
-          </label>
-
-          <!-- 実行ボタン -->
-          <%= button_to "OK",
-                        increment_stock_user_medicine_path(user_medicine),
-                        method: :patch,
-                        class: "btn btn-primary",
-                        form: { onsubmit: "document.getElementById('forgot-modal-#{user_medicine.id}').checked = false;" } %>
-        </div>
-      </div>
-    </div>
-  <% end %>
-<% end %>

--- a/app/views/user_medicines/forgot_index.html.erb
+++ b/app/views/user_medicines/forgot_index.html.erb
@@ -1,23 +1,25 @@
 <div class="container mx-auto px-4 py-8">
-  <h1 class="font-bold text-4xl text-center mb-6">飲み忘れ</h1>
-  <div class="bg-white max-w-4xl mx-auto rounded-lg shadow mb-6">
-    <% if @medicines_with_stock.any? %>
-      <% @medicines_with_stock.each do |user_medicine| %>
-        <div class="flex items-center justify-between p-4 border-b hover:bg-gray-50 mb-4">
-          <div class="flex-1">
-            <div class="flex items-center gap-2">
-              <h3 class="font-semibold text-lg"><%= user_medicine.medicine.name %></h3>
+  <div class="medicines-section max-w-2xl mx-auto mb-8">
+    <h1 class="font-bold text-4xl text-center mb-6">飲み忘れ</h1>
+    <div class="bg-white max-w-4xl mx-auto rounded-lg shadow mb-6">
+      <% if @medicines_with_stock.any? %>
+        <% @medicines_with_stock.each do |user_medicine| %>
+          <div class="flex items-center justify-between p-4 border-b hover:bg-gray-50 mb-4">
+            <div class="flex-1">
+              <div class="flex items-center gap-2">
+                <h3 class="font-semibold text-lg"><%= user_medicine.medicine.name %></h3>
+              </div>
+              <p class="text-gray-600">残り<%= user_medicine.current_stock %>錠</p>
             </div>
-            <p class="text-gray-600">残り<%= user_medicine.current_stock %>錠</p>
+            <label for="forgot-modal-<%= user_medicine.id %>" class="btn btn-secondary">
+              飲み忘れ
+            </label>
           </div>
-          <label for="forgot-modal-<%= user_medicine.id %>" class="btn btn-secondary">
-            飲み忘れ
-          </label>
-        </div>
+        <% end %>
+      <% else %>
+        <p class="text-center py-8">現在、薬はありません</p>
       <% end %>
-    <% else %>
-      <p class="text-center py-8">現在、薬はありません</p>
-    <% end %>
+    </div>
   </div>
 </div>
 
@@ -40,10 +42,10 @@
 
           <!-- 実行ボタン -->
           <%= button_to "OK",
-              increment_stock_user_medicine_path(user_medicine),
-              method: :patch,
-              class: "btn btn-primary",
-              form: { onsubmit: "document.getElementById('forgot-modal-#{user_medicine.id}').checked = false;" } %>
+                        increment_stock_user_medicine_path(user_medicine),
+                        method: :patch,
+                        class: "btn btn-primary",
+                        form: { onsubmit: "document.getElementById('forgot-modal-#{user_medicine.id}').checked = false;" } %>
         </div>
       </div>
     </div>

--- a/app/views/user_medicines/index.html.erb
+++ b/app/views/user_medicines/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container mx-auto px-4 mb-20">
   <div class="medicines-section max-w-2xl mx-auto mb-8">
-    <h1 class="text-3xl text-center mb-6 mt-2" style="font-family: 'M PLUS Rounded 1c', sans-serif; font-weight: 500;">
+    <h1 class="text-3xl text-center mb-4 mt-6" style="font-family: 'M PLUS Rounded 1c', sans-serif; font-weight: 500;">
       <i class="fa-solid fa-pills" style="color: rgba(255, 136, 59, 1.00);"></i>お薬リスト
     </h1>
 

--- a/app/views/user_medicines/index.html.erb
+++ b/app/views/user_medicines/index.html.erb
@@ -2,8 +2,10 @@
   <h1 class="text-3xl text-center mb-6 mt-2" style="font-family: 'M PLUS Rounded 1c', sans-serif; font-weight: 500;">
     <i class="fa-solid fa-pills" style="color: rgba(255, 136, 59, 1.00);"></i>お薬リスト
   </h1>
+
+  <!-- 薬一覧 -->
   <div class="bg-white max-w-4xl mx-auto rounded-lg shadow mb-6">
-    <%if @user_medicine.any? %>
+    <% if @user_medicine.any? %>
       <% @user_medicine.each do |user_medicine| %>
         <div class="flex items-center justify-between p-4 border-b hover:bg-gray-50 mb-4">
           <div class="flex-1">
@@ -23,8 +25,9 @@
     <% end %>
    </div>
 
-  <div class="actions text-center">
-    <%= link_to new_user_medicine_path, class: "btn bg-white text-[#E56A54] border border-[#E56A54] max-w-xs" do%>
+    <!-- 新しいお薬登録ボタン -->
+    <div class="actions text-center">
+    <%= link_to new_user_medicine_path, class: "btn bg-white text-[#E56A54] border border-[#E56A54] max-w-xs hover:bg-red-100 transition-colors duration-300" do %>
       <i class="fa-solid fa-plus fa-sm" style="color: rgba(255, 136, 59, 1.00);"></i>
       新しいお薬を登録する
     <% end %>

--- a/app/views/user_medicines/index.html.erb
+++ b/app/views/user_medicines/index.html.erb
@@ -1,5 +1,7 @@
 <div class="container mx-auto px-4 mb-20">
-  <h1 class="font-bold text-4xl text-center mb-6">薬一覧</h1>
+  <h1 class="text-3xl text-center mb-6 mt-2" style="font-family: 'M PLUS Rounded 1c', sans-serif; font-weight: 500;">
+    <i class="fa-solid fa-pills" style="color: rgba(255, 136, 59, 1.00);"></i>お薬リスト
+  </h1>
   <div class="bg-white max-w-4xl mx-auto rounded-lg shadow mb-6">
     <%if @user_medicine.any? %>
       <% @user_medicine.each do |user_medicine| %>
@@ -22,6 +24,9 @@
    </div>
 
   <div class="actions text-center">
-    <%= link_to "新規登録", new_user_medicine_path, class: "btn bg-white text-[#E56A54] border border-[#E56A54] w-full max-w-xs" %>
+    <%= link_to new_user_medicine_path, class: "btn bg-white text-[#E56A54] border border-[#E56A54] max-w-xs" do%>
+      <i class="fa-solid fa-plus fa-sm" style="color: rgba(255, 136, 59, 1.00);"></i>
+      新しいお薬を登録する
+    <% end %>
   </div>
 </div>

--- a/app/views/user_medicines/index.html.erb
+++ b/app/views/user_medicines/index.html.erb
@@ -1,35 +1,37 @@
 <div class="container mx-auto px-4 mb-20">
-  <h1 class="text-3xl text-center mb-6 mt-2" style="font-family: 'M PLUS Rounded 1c', sans-serif; font-weight: 500;">
-    <i class="fa-solid fa-pills" style="color: rgba(255, 136, 59, 1.00);"></i>お薬リスト
-  </h1>
+  <div class="medicines-section max-w-2xl mx-auto mb-8">
+    <h1 class="text-3xl text-center mb-6 mt-2" style="font-family: 'M PLUS Rounded 1c', sans-serif; font-weight: 500;">
+      <i class="fa-solid fa-pills" style="color: rgba(255, 136, 59, 1.00);"></i>お薬リスト
+    </h1>
 
-  <!-- 薬一覧 -->
-  <div class="bg-white max-w-4xl mx-auto rounded-lg shadow mb-6">
-    <% if @user_medicine.any? %>
-      <% @user_medicine.each do |user_medicine| %>
-        <div class="flex items-center justify-between p-4 border-b hover:bg-gray-50 mb-4">
-          <div class="flex-1">
-            <div class="flex items-center gap-2">
-              <h3 class="font-semibold text-lg"><%= user_medicine.medicine.name %></h3>
+    <!-- 薬一覧 -->
+    <div class="bg-white max-w-4xl mx-auto rounded-lg shadow mb-6">
+      <% if @user_medicine.any? %>
+        <% @user_medicine.each do |user_medicine| %>
+          <div class="flex items-center justify-between p-4 border-b hover:bg-gray-50 mb-4">
+            <div class="flex-1">
+              <div class="flex items-center gap-2">
+                <h3 class="font-semibold text-lg"><%= user_medicine.medicine.name %></h3>
+              </div>
+              <p class="text-gray-600">1回の服薬量：<%= user_medicine.dosage_per_time %>錠</p>
             </div>
-            <p class="text-gray-600">1回の服薬量：<%= user_medicine.dosage_per_time %>錠</p>
+            <% if user_medicine.current_stock > 0 %>
+              <span class="bg-red-100 text-red-600 text-xs font-medium px-2 py-0.5 rounded mr-2">服薬中</span>
+            <% end %>
+            <%= link_to "選択", user_medicine_path(user_medicine), class: "px-4 py-2 btn btn-primary" %>
           </div>
-          <% if user_medicine.current_stock > 0 %>
-            <span class="bg-red-100 text-red-600 text-xs font-medium px-2 py-0.5 rounded mr-2">服薬中</span>
-          <% end %>
-          <%= link_to "選択", user_medicine_path(user_medicine), class: "px-4 py-2 btn btn-primary" %>
-        </div>
+        <% end %>
+      <% else %>
+        <p class="text-center py-8">現在、薬はありません</p>
       <% end %>
-    <% else %>
-      <p class="text-center py-8">現在、薬はありません</p>
-    <% end %>
-   </div>
+    </div>
 
-    <!-- 新しいお薬登録ボタン -->
-    <div class="actions text-center">
-    <%= link_to new_user_medicine_path, class: "btn bg-white text-[#E56A54] border border-[#E56A54] max-w-xs hover:bg-red-100 transition-colors duration-300" do %>
-      <i class="fa-solid fa-plus fa-sm" style="color: rgba(255, 136, 59, 1.00);"></i>
-      新しいお薬を登録する
-    <% end %>
+      <!-- 新しいお薬登録ボタン -->
+      <div class="actions text-center">
+      <%= link_to new_user_medicine_path, class: "btn bg-white text-[#E56A54] border border-[#E56A54] max-w-xs hover:bg-red-100 transition-colors duration-300" do %>
+        <i class="fa-solid fa-plus fa-sm" style="color: rgba(255, 136, 59, 1.00);"></i>
+        新しいお薬を登録する
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/user_medicines/new.html.erb
+++ b/app/views/user_medicines/new.html.erb
@@ -1,7 +1,9 @@
-<div class="container mx-auto px-4">
-  <div class="medicines-section max-w-4xl mx-auto mb-8">
+<div class="container mx-auto px-4 mb-16">
+  <div class="medicines-section max-w-2xl mx-auto mb-8">
     <div class="w-full">
-      <h1 class="font-bold text-4xl text-center mb-6">新規登録</h1>
+      <h1 class="text-3xl text-center mb-2 mt-2" style="font-family: 'M PLUS Rounded 1c', sans-serif; font-weight: 500;">
+        <i class="fa-solid fa-pills" style="color: rgba(255, 136, 59, 1.00);"></i>お薬登録
+      </h1>
 
       <div class="bg-white rounded-lg shadow p-6">
         <%= form_with model: @form, url: user_medicines_path do |f| %>
@@ -9,10 +11,10 @@
 
           <div class="mb-4" data-controller="autocomplete">
             <%= f.label :medicine_name, "薬名", class: "block text-sm font-bold mb-2" %>
-            <div class="relative">
+            <div class="relative w-full">
             <!-- input ターゲット -->
               <%= f.text_field :medicine_name,
-                               class: "flex-1 border border-gray-300 rounded px-3 py-2 w-full",
+                               class: form_field_class(f.object, :medicine_name),
                                autocomplete: "off",
                                data: {
                                  autocomplete_target: "input",
@@ -29,10 +31,14 @@
             <%= f.label :dosage_per_time, "1回の服薬量", class: "block text-sm font-bold mb-2" %>
             <div class="flex items-center gap-2">
               <%= f.number_field :dosage_per_time,
-                                 min: 1,
-                                 class: "border border-gray-300 rounded px-3 py-2" %>
+                                min: 1,
+                                class: form_field_class(f.object, :dosage_per_time) %>
               <span class="text-gray-700 whitespace-nowrap">錠</span>
             </div>
+            <% if f.object.errors[:dosage_per_time].any? %>
+              <p class="text-red-600 text-sm mt-1">
+              </p>
+            <% end %>
           </div>
 
           <div class="mb-4">
@@ -40,7 +46,7 @@
             <div class="flex items-center gap-2">
               <%= f.number_field :times_per_day,
                                  max: 4,
-                                 class: "border border-gray-300 rounded px-3 py-2" %>
+                                 class: form_field_class(f.object, :times_per_day) %>
               <span class="text-gray-700 whitespace-nowrap">回</span>
             </div>
           </div>
@@ -51,7 +57,7 @@
               <%= f.number_field :prescribed_amount,
                                  placeholder: "追加する数量を入力",
                                  min: 1,
-                                 class: "border border-gray-300 rounded px-3 py-2" %>
+                                 class: form_field_class(f.object, :prescribed_amount) %>
               <span class="text-gray-700 whitespace-nowrap">錠</span>
             </div>
           </div>
@@ -60,7 +66,7 @@
             <%= f.label :date_of_prescription, "処方日", class: "block text-sm font-bold mb-2" %>
             <%= f.date_field :date_of_prescription,
                              value: Date.today,
-                             class: "border border-gray-300 rounded px-3 py-2" %>
+                             class: form_field_class(f.object, :date_of_prescription) %>
           </div>
 
           <div class="flex gap-4">

--- a/app/views/user_medicines/new.html.erb
+++ b/app/views/user_medicines/new.html.erb
@@ -1,7 +1,16 @@
 <div class="container mx-auto px-4 mb-16">
   <div class="medicines-section max-w-2xl mx-auto mb-8">
     <div class="w-full">
-      <h1 class="text-3xl text-center mb-2 mt-2" style="font-family: 'M PLUS Rounded 1c', sans-serif; font-weight: 500;">
+
+    <!-- 薬一覧へのボタン-->
+     <div class="flex mt-2 mb-2">
+       <%= link_to user_medicines_path, class: "text-gray-800 hover:text-red-500 inline-flex items-center gap-2 transition-colors duration-200" do %>
+        <i class="fa-solid fa-arrow-left fa-sm"></i>
+        <span>薬一覧へ</span>
+      <% end %>
+      </div>
+
+      <h1 class="text-3xl text-center mb-4" style="font-family: 'M PLUS Rounded 1c', sans-serif; font-weight: 500;">
         <i class="fa-solid fa-pills" style="color: rgba(255, 136, 59, 1.00);"></i>お薬登録
       </h1>
 
@@ -66,12 +75,12 @@
             <%= f.label :date_of_prescription, "処方日", class: "block text-sm font-bold mb-2" %>
             <%= f.date_field :date_of_prescription,
                              value: Date.today,
-                             class: form_field_class(f.object, :date_of_prescription) %>
+                             class: date_form_field_class(f.object, :date_of_prescription) %>
           </div>
 
-          <div class="flex gap-4">
-            <%= f.submit "薬を追加", class: "btn btn-primary flex-1" %>
-            <%= link_to "戻る", user_medicines_path, class: "btn btn-neutral flex-1" %>
+          <!-- 薬を追加ボタン -->
+          <div class="actions text-center">
+            <%= f.submit "薬を追加", class: "btn btn-primary" %>
           </div>
         <% end %>
       </div>

--- a/app/views/user_medicines/show.html.erb
+++ b/app/views/user_medicines/show.html.erb
@@ -1,6 +1,20 @@
-<div class="container mx-auto px-4">
+<div class="container mx-auto px-4 mb-16">
   <div class="medicines-section max-w-4xl mx-auto mb-8">
     <div class="w-full">
+
+    <!-- 薬一覧へのボタン-->
+     <div class="flex mt-2 mb-2">
+        <%= link_to user_medicines_path, class: "link link-primary hover:link-hover" do %>
+          <i class="fa-solid fa-arrow-left fa-sm"></i>
+          <span class="ml-2">薬一覧へ</span>
+        <% end %>
+      </div>
+
+      <!-- タイトル -->
+      <h1 class="text-3xl text-center mb-6 mt-2" style="font-family: 'M PLUS Rounded 1c', sans-serif; font-weight: 500;">
+        <i class="fa-solid fa-pills" style="color: rgba(255, 136, 59, 1.00);"></i><%= @user_medicine.medicine.name %>
+      </h1>
+
       <div class="bg-white rounded-lg shadow p-6">
         <!-- 削除アイコン -->
         <div class="flex justify-end">
@@ -10,13 +24,8 @@
             <i class="fa-solid fa-trash fa-lg"></i>
           <% end %>
         </div>
-        <div class="mb-4">
-          <label class="block text-sm font-bold mb-2">薬名</label>
-          <div class="bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-700">
-            <%= @user_medicine.medicine.name %>
-          </div>
-        </div>
 
+        <!-- 薬の詳細 -->
         <div class="mb-4">
           <label class="block text-sm font-bold mb-2">1回の服薬量</label>
           <div class="bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-700">
@@ -69,12 +78,6 @@
                             form: { class: "flex-1" },
                             class: "btn btn-secondary w-full" %>
             <% end %>
-          </div>
-          <div class="mt-10 flex justify-end">
-            <%= link_to "戻る", :back, class: "btn btn-neutral" %>
-          </div>
-          <div class="mt-10 flex justify-end">
-            <%= link_to "薬一覧", user_medicines_path, class: "btn btn-neutral" %>
           </div>
         </div>
        </div>

--- a/app/views/user_medicines/show.html.erb
+++ b/app/views/user_medicines/show.html.erb
@@ -4,10 +4,10 @@
 
     <!-- 薬一覧へのボタン-->
      <div class="flex mt-2 mb-2">
-        <%= link_to user_medicines_path, class: "link link-primary hover:link-hover" do %>
-          <i class="fa-solid fa-arrow-left fa-sm"></i>
-          <span class="ml-2">薬一覧へ</span>
-        <% end %>
+       <%= link_to user_medicines_path, class: "text-gray-800 hover:text-red-500 inline-flex items-center gap-2 transition-colors duration-200" do %>
+        <i class="fa-solid fa-arrow-left fa-sm"></i>
+        <span>薬一覧へ</span>
+      <% end %>
       </div>
 
       <!-- タイトル -->

--- a/app/views/user_medicines/show.html.erb
+++ b/app/views/user_medicines/show.html.erb
@@ -69,14 +69,11 @@
                           form: { class: "flex-1" },
                           class: "btn btn-primary w-full" %>
             <% if @user_medicine.has_stock? %>
-              <%= button_to "飲み忘れ",
-                            increment_stock_user_medicine_path(@user_medicine),
-                            method: :patch,
-                            data: {
-                              turbo_confirm: "#{@user_medicine.medicine.name}は現在残り#{@user_medicine.current_stock}錠です。1回分増やしますか？",
-                            },
-                            form: { class: "flex-1" },
-                            class: "btn btn-secondary w-full" %>
+              <div class="flex-1">
+                <label for="confirm-modal-<%= @user_medicine.id %>" class="btn btn-secondary w-full cursor-pointer">
+                  飲み忘れ
+                </label>
+              </div>
             <% end %>
           </div>
         </div>
@@ -84,4 +81,29 @@
       </div>
     </div>
   </div>
+</div>
+
+<!-- モーダルの中身 -->
+<input type="checkbox" id="confirm-modal-<%= @user_medicine.id %>" class="modal-toggle" />
+<div class="modal">
+  <div class="modal-box">
+    <h3 class="font-bold text-lg">飲み忘れの確認</h3>
+      <p class="py-4">
+      <%= @user_medicine.medicine.name %>は現在残り<%= @user_medicine.current_stock %>錠です。<br>
+      1回分増やしますか？
+    </p>
+    <div class="modal-action">
+      <label for="confirm-modal-<%= @user_medicine.id %>" class="btn ">
+        キャンセル
+      </label>
+      <%= button_to "OK",
+                    increment_stock_user_medicine_path(@user_medicine),
+                    method: :patch,
+                    form: { class: "inline" },
+                    class: "btn btn-primary" %>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="button">close</button>
+  </form>
 </div>

--- a/app/views/user_medicines/show.html.erb
+++ b/app/views/user_medicines/show.html.erb
@@ -1,5 +1,5 @@
 <div class="container mx-auto px-4 mb-16">
-  <div class="medicines-section max-w-4xl mx-auto mb-8">
+  <div class="medicines-section max-w-2xl mx-auto mb-8">
     <div class="w-full">
 
     <!-- 薬一覧へのボタン-->

--- a/app/views/user_medicines/show.html.erb
+++ b/app/views/user_medicines/show.html.erb
@@ -84,26 +84,4 @@
 </div>
 
 <!-- モーダルの中身 -->
-<input type="checkbox" id="confirm-modal-<%= @user_medicine.id %>" class="modal-toggle" />
-<div class="modal">
-  <div class="modal-box">
-    <h3 class="font-bold text-lg">飲み忘れの確認</h3>
-      <p class="py-4">
-      <%= @user_medicine.medicine.name %>は現在残り<%= @user_medicine.current_stock %>錠です。<br>
-      1回分増やしますか？
-    </p>
-    <div class="modal-action">
-      <label for="confirm-modal-<%= @user_medicine.id %>" class="btn ">
-        キャンセル
-      </label>
-      <%= button_to "OK",
-                    increment_stock_user_medicine_path(@user_medicine),
-                    method: :patch,
-                    form: { class: "inline" },
-                    class: "btn btn-primary" %>
-    </div>
-  </div>
-  <form method="dialog" class="modal-backdrop">
-    <button type="button">close</button>
-  </form>
-</div>
+<%= render "increment_stock_modal", user_medicine: @user_medicine %>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets --loader:.woff2=file --loader:.woff=file --loader:.ttf=file --loader:.eot=file --loader:.css=css",
+    "build:css": "tailwindcss -i ./app/assets/stylesheets/tailwind/application.css -o ./app/assets/builds/tailwind.css",
     "postinstall": "cp -r node_modules/@fortawesome/fontawesome-free/webfonts public/assets/"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets --loader:.woff2=file --loader:.woff=file --loader:.ttf=file --loader:.eot=file --loader:.css=css",
-    "build:css": "tailwindcss -i ./app/assets/stylesheets/tailwind/application.css -o ./app/assets/builds/tailwind.css",
+    "build:css": "tailwindcss -i ./app/assets/tailwind/application.css -o ./app/assets/builds/tailwind.css",
+    "build:css:watch": "tailwindcss -i ./app/assets/tailwind/application.css -o ./app/assets/builds/tailwind.css --watch",
     "postinstall": "cp -r node_modules/@fortawesome/fontawesome-free/webfonts public/assets/"
   },
   "dependencies": {

--- a/spec/system/hospitals_spec.rb
+++ b/spec/system/hospitals_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe "Hospitals", type: :system do
 
           click_button "変更"
 
-          sleep 5
+          sleep 3
           expect(current_path).to eq hospital_path(hospital)
           expect(page).to have_content "病院情報を更新しました"
           # expect(page).to have_content("10:00 - 13:00")

--- a/spec/system/user_medicines_spec.rb
+++ b/spec/system/user_medicines_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "UserMedicines", type: :system do
           visit add_stock_user_medicine_path(user_medicine)
           fill_in "処方量", with: "30"
           fill_in "処方日", with: Date.current
-          click_button "在庫を追加する"
+          click_button "保存する"
           expect(page).to have_content "薬を追加しました"
           expect(current_path).to eq user_medicines_path
         end
@@ -102,7 +102,7 @@ RSpec.describe "UserMedicines", type: :system do
         context "在庫がある場合" do
           let(:user_medicine) { create(:user_medicine, user: user, medicine: medicine, current_stock: 10) }
           it "飲み忘れボタンが表示される" do
-            expect(page).to have_button("飲み忘れ"), "在庫がある場合、飲み忘れボタンが表示されていません"
+            expect(page).to have_css("label.btn.btn-secondary", text: "飲み忘れ"), "在庫がある場合、飲み忘れボタンが表示されていません"
           end
         end
 
@@ -121,9 +121,8 @@ RSpec.describe "UserMedicines", type: :system do
         end
 
         it "確認ダイアログが表示され、はいを押すと在庫量が1回の服薬量分増える" do
-          accept_confirm do
-            click_button "飲み忘れ"
-          end
+          find("label.btn.btn-secondary", text: "飲み忘れ").click
+          click_button "OK"
 
           expect(page).to have_content("在庫を1回分増やしました"), "フラッシュメッセージが表示されていません"
           expect(page).to have_content("現在の在庫")
@@ -132,9 +131,8 @@ RSpec.describe "UserMedicines", type: :system do
         end
 
         it "確認ダイアログでいいえを押すと在庫量が変わらない" do
-          dismiss_confirm do
-            click_button "飲み忘れ"
-          end
+          find("label.btn.btn-secondary", text: "飲み忘れ").click
+          find("label.btn", text: "キャンセル").click
 
           expect(page).to have_content("現在の在庫")
           expect(page).to have_content("10 錠"), "在庫量の表示が変わってしまっています（期待値: 10 錠）"


### PR DESCRIPTION
### 概要

issue [#212]
薬一覧、詳細、作成、在庫追加、飲み忘れの画面のデザインをブラッシュアップしました。
フラッシュメッセージ、エラー表示、飲み忘れの確認ダイアログを修正しました。

### 作業内容
**フラッシュメッセージ**
色を分かりやすく分けて、3秒で消えるようにしました。
1. app/helpers/application_helper.rb
noticeは緑、alertは赤の背景を付ける`flash_background_color `を作成
2. app/views/shared/_flash_message.html.erb
ヘルパーで作った`flash_background_color `を呼び出す記述
3. app/javascript/controllers/flash_controller.js
3秒で消える実装

**入力エラーメッセージ**
フォーム入力が不正な場合に該当フォームが赤くなるようにと、画面上部にまとめて出すエラー表示を分かりやすくしました。
1. app/helpers/application_helper.rb
入力でエラーが出たフォームを赤にする`form_field_class `をメソッド化
2. app/views/shared/_error_messages.html.erb
エラーの背景を赤と赤の枠線にし、目立つように修正
3. app/views/user_medicines/add_stock.html.erb、app/views/user_medicines/new.html.erb
フォームに`class: form_field_class(f.object, :prescribed_amount)`のように記述

**文字のフォント**
ページタイトルに丸みのあるフォントを使いました。
1. app/views/layouts/application.html.erb
読み込み
2. app/views/user_medicines/index.html.erbなど各ページのタイトル
`style="font-family: 'M PLUS Rounded 1c', sans-serif;`のように指定

**飲み忘れ調整機能をモーダル表示**
ブラウザの確認ダイアログを使用していましたが、モーダルで確認画面を表示するように変更しました。
1. app/views/user_medicines/_increment_stock_modal.html.erb
モーダルの中身部分をテンプレート化
2. app/views/user_medicines/forgot_index.html.erb、app/views/user_medicines/show.html.erb
クリック部分の`<label for="confirm-modal-<%= @user_medicine.id %>`と中身呼び出し部分お`<%= render "increment_stock_modal", user_medicine: @user_medicine %>`を記述

### 機能追加理由
フラッシュメッセージはずっと表示する必要が薄いので3秒で消えるようにしました。エラーはエラーだと分かりやすいように赤色で強調し、どのフォームでエラーが出たのか分かりやすくなるようにしました。