### PR TITLE
【Feature】お問い合わせフォームを実装

### DIFF
--- a/app/views/shared/_before_login_drawer_menu.html.erb
+++ b/app/views/shared/_before_login_drawer_menu.html.erb
@@ -8,6 +8,6 @@
     <li><%= link_to "使い方", "_path" %></li>
     <li><%= link_to "利用規約", terms_of_service_path %></li>
     <li><%= link_to "プライバシーポリシー", privacy_path %></li>
-    <li><%= link_to "お問合せ", "contact_path" %></li>
+    <li><%= link_to "お問い合わせ", "https://docs.google.com/forms/d/e/1FAIpQLSfDG16MSVZUjgetz9KKfY7MROubS1F45IzY4MUAFmP2WE5WNA/viewform?usp=header", target: "_blank" %></li>
   </ul>
 </div>

--- a/app/views/shared/_drawer_menu.html.erb
+++ b/app/views/shared/_drawer_menu.html.erb
@@ -14,7 +14,7 @@
     <li><%= link_to "使い方", "_path" %></li>
     <li><%= link_to "利用規約", terms_of_service_path %></li>
     <li><%= link_to "プライバシーポリシー", privacy_path %></li>
-    <li><%= link_to "お問合せ", "contact_path" %></li>
+    <li><%= link_to "お問い合わせ", "https://docs.google.com/forms/d/e/1FAIpQLSfDG16MSVZUjgetz9KKfY7MROubS1F45IzY4MUAFmP2WE5WNA/viewform?usp=header", target: "_blank" %></li>
     <li><%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete, confirm: "ログアウトしますか？", turbo_confirm: "ログアウトしますか？" } %></li>
   </ul>
 </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,7 +3,7 @@
     <div class="flex flex-wrap justify-center gap-x-8 gap-y-4 mb-4">
       <%= link_to "利用規約", terms_of_service_path, class: "text-xs font-bold text-stone-400 hover:text-red-500 transition-colors" %>
       <%= link_to "プライバシーポリシー", privacy_path, class: "text-xs font-bold text-stone-400 hover:text-red-500 transition-colors" %>
-      <%= link_to "お問い合わせ", "contact_path", class: "text-xs font-bold text-stone-400 hover:text-red-500 transition-colors" %>
+      <%= link_to "お問い合わせ", "https://docs.google.com/forms/d/e/1FAIpQLSfDG16MSVZUjgetz9KKfY7MROubS1F45IzY4MUAFmP2WE5WNA/viewform?usp=header", target: "_blank", class: "text-xs font-bold text-stone-400 hover:text-red-500 transition-colors" %>
     </div>
 
     <div class="flex flex-col items-center gap-2">

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -51,7 +51,7 @@
       お客様の情報の開示、情報の訂正、利用停止、削除をご希望の場合は、お問い合わせフォームよりご連絡ください。
     </p>
     <p class="mb-8">
-      <%= link_to "お問い合わせフォームはこちら", "contact_path", class: "text-blue-600 hover:underline font-semibold" %>
+      <%= link_to "お問い合わせフォームはこちら", "https://docs.google.com/forms/d/e/1FAIpQLSfDG16MSVZUjgetz9KKfY7MROubS1F45IzY4MUAFmP2WE5WNA/viewform?usp=header", target: "_blank", class: "text-blue-600 hover:underline font-semibold" %>
     </p>
     <p class="mb-6">
       この場合、必ず、運転免許証のご提示等当社が指定する方法により、ご本人からのご請求であることの確認をさせていただきます。なお、情報の開示請求については、開示の有無に関わらず、ご申請時に一件あたり1,000円の事務手数料を申し受けます。

--- a/spec/system/footer_spec.rb
+++ b/spec/system/footer_spec.rb
@@ -33,11 +33,13 @@ RSpec.describe "フッター", type: :system do
       expect(page).to have_current_path(privacy_path)
     end
 
-    # it "お問い合わせリンクをクリックするとお問い合わせページに遷移すること" do
-    #   within("footer") do
-    #     click_on "お問い合わせ"
-    #   end
-    #   expect(page).to have_current_path(contact_path)
-    # end
+    it "お問い合わせリンクをクリックするとお問い合わせページに遷移すること" do
+      within("footer") do
+        expect(page).to have_link(
+        "お問い合わせ",
+        href: "https://docs.google.com/forms/d/e/1FAIpQLSfDG16MSVZUjgetz9KKfY7MROubS1F45IzY4MUAFmP2WE5WNA/viewform?usp=header"
+        )
+      end
+    end
   end
 end

--- a/spec/system/header_spec.rb
+++ b/spec/system/header_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "ヘッダー", type: :system do
         expect(page).to have_link "使い方"
         expect(page).to have_link "利用規約"
         expect(page).to have_link "プライバシーポリシー"
-        expect(page).to have_link "お問合せ"
+        expect(page).to have_link "お問い合わせ"
         expect(page).to have_link "ログアウト"
       end
 

--- a/spec/system/header_spec.rb
+++ b/spec/system/header_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe "ヘッダー", type: :system do
 
     context "ハンバーガーメニュー" do
       before do
-        # ハンバーガーメニューを開く（実際のクラス名やIDに合わせて調整してください）
         find(".drawer-button").click
       end
 
@@ -68,17 +67,19 @@ RSpec.describe "ヘッダー", type: :system do
         expect(page).to have_current_path(privacy_path)
       end
 
-      # it "お問い合わせリンクをクリックするとお問い合わせページに遷移すること" do
-      #   click_on "お問い合わせ"
-      #   expect(page).to have_current_path(_path)
-      # end
+      it "お問い合わせリンクをクリックするとお問い合わせページに遷移すること" do
+        within("footer") do
+          expect(page).to have_link(
+          "お問い合わせ",
+          href: "https://docs.google.com/forms/d/e/1FAIpQLSfDG16MSVZUjgetz9KKfY7MROubS1F45IzY4MUAFmP2WE5WNA/viewform?usp=header"
+          )
+        end
+      end
 
       it "ログアウトリンクをクリックするとログアウトできること" do
-        # 確認ダイアログを自動的に承認する
         accept_confirm do
           click_on "ログアウト"
         end
-        # ログアウト後の遷移先に合わせて調整してください
         expect(page).to have_current_path(root_path)
       end
     end


### PR DESCRIPTION
### 概要

issue [#99]
Googleフォームでお問い合わせフォームを作成し、アプリにリンクを埋め込みました。

### 作業内容
1. Googleフォームでお問い合わせフォームを作成
2. お問い合わせに作成したリンクを貼り、別タブで開くために`target: "_blank"`を指定
  - app/views/shared/_before_login_drawer_menu.html.erb（ログイン前のハンバーガーメニュー）
  - app/views/shared/_drawer_menu.html.erb（ログイン後のハンバーガーメニュー）
  - app/views/shared/_footer.html.erb（フッター）
  - app/views/static_pages/privacy.html.erb（プライバシーポリシーの中）
 3. お問い合わせを押したらお問い合わせページに遷移するかのテストを記述
  - spec/system/header_spec.rb
  - spec/system/footer_spec.rb
 
### 機能追加理由

ユーザーが開発者にコンタクトを取れることで安心感があると思い作成しました。見慣れたGoogleフォームだとユーザーが使いやすいと考えてGoogleフォームで実装しました。
