### PR TITLE
【chore】カスタムドメインを設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,10 +96,10 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
+  config.hosts = [
+    "okusurikanri-okan.com",
+    "www.okusurikanri-okan.com"
+  ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
### 概要

issue [#102]


### 作業内容
1. xserverでカスタムドメイン`okusurikanri-okan.com`を取得
2. RenderでCustom Domainsに取得したドメインを設定
3. config/environments/production.rb
`okusurikanri-okan.com`と`www.okusurikanri-okan.com`を許可する記述

### 機能追加理由
信頼性向上、SEO対策のために独自ドメインを取得しました。

### 備考
`.onrender.com`のドメインではconfig/environments/production.rbに設定を追加しなくても使えていたのはRenderが自動的に設定を追加していたため。今回のカスタムドメインはRenderが知らないドメインなので開発者側で明示的に許可する必要があった。