### PR TITLE
【fix】READMEにER図の画像が表示されるよう修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ https://okusurikanri-okan.com
 | 項目 | 技術 |
 | --- | --- |
 | バックエンド | Ruby 3.3.10 / Ruby on Rails 7.2.3 |
-| フロントエンド |  TailwindCSS / daisyUI /Hotwire（Turbo, Stimulus） |
+| フロントエンド |  TailwindCSS / daisyUI / Hotwire（Turbo, Stimulus） |
 | データベース | PostgreSQL |
 | 認証 | Devise / OmniAuth（Google, LINE） |
-| タスク管理 | Whenever / GitHub Actions（cron） |
+| タスク管理 | Whenever / GitHub Actions |
 | 外部API | LINE Messaging API |
 | 開発環境 | Docker |
-| 本番環境 | Render / neon(db) |
+| 本番環境 | Render / neon(DB) |
 | その他 | rubocop / RSpec / FactoryBot|
 
 ## サービスの差別化ポイント・推しポイント

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ https://okusurikanri-okan.com
 Figma：https://www.figma.com/design/TKYTGl8lAQCmwPjlHiZIoV/%E9%80%9A%E9%99%A2%E7%AE%A1%E7%90%86%E3%82%A2%E3%83%97%E3%83%AA%E3%80%80%E7%94%BB%E9%9D%A2%E9%81%B7%E7%A7%BB%E5%9B%B3?node-id=0-1&p=f&t=oTOPyTQU20oXrSg8-0
 
 ### ER図
-![ER図](docs/db_okan.png)
+![ER図](docs/images/db_okan.png)
 
 詳細なテーブル定義は [こちら](docs/table_definition.md) をご覧ください。
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,10 +96,10 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  config.hosts = [
-    "okusurikanri-okan.com",
-    "www.okusurikanri-okan.com"
-  ]
+  config.hosts << "okusurikanri-okan.com"
+  config.hosts << "www.okusurikanri-okan.com"
+  config.hosts << "okan-8iqv.onrender.com"
+
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
### 概要

issue[# 240]
READMEにER図の画像が表示されるよう修正しました。
独自ドメインのホワイトリストに追加する記述を変更しました。

### 作業内容

- README.md
db_okan.pngを保存している正しいパスに変更

- config/environments/production.rb
上書きする書き方ではなく追加する書き方に変更

### 備考
VSCodeのプレビューでER図が表示されていることを確認しました。