### PR TITLE
【change】wheneverのバージョン1.1.2に更新

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem "devise", "~> 5.0.1"
 gem "devise-i18n", "~> 1.15"
 gem "simple_calendar",  "3.1.0"
 gem "kaminari",  "1.2.2"
-gem "whenever", "1.1.1", require: false
+gem "whenever", "1.1.2", require: false
 gem "omniauth-google-oauth2", "1.2.1"
 gem "omniauth-line", "0.1.0"
 gem "omniauth-rails_csrf_protection", "2.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -464,7 +464,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    whenever (1.1.1)
+    whenever (1.1.2)
       chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -516,7 +516,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
-  whenever (= 1.1.1)
+  whenever (= 1.1.2)
 
 CHECKSUMS
   actioncable (7.2.3) sha256=e15d17b245f1dfe7cafdda4a0c6f7ba8ebaab1af33884415e09cfef4e93ad4f9
@@ -696,7 +696,7 @@ CHECKSUMS
   websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
-  whenever (1.1.1) sha256=ffe23b598cb27e90f65c25bc9cc45f7537ed7e0e20a6766cab1b9c1a069912d2
+  whenever (1.1.2) sha256=af139a25cf6b5c7d2122686724c0b9a4a7495135a1f79a404e29f4cce48abd83
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd
 


### PR DESCRIPTION
### 概要

PR[#151]
dependantbotでwheneverのバージョンアップがうまくいかなかったため手動で行いました。

### 作業内容
1. Gemfile
wheneverのバージョンを1.1.1から1.1.2に変更
2. `docker compose exec web bundle install`を実行
