### PR TITLE
【change】checkout@v4をv6に変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code # GitHubリポジトリのコードを仮想マシン上にコピー（クローン）する
-        uses: actions/checkout@v4 #「GitHubが提供する「コードをチェックアウトする処理」のバージョン4を使う
+        uses: actions/checkout@v6 #「GitHubが提供する「コードをチェックアウトする処理」のバージョン4を使う
 
       - name: Set up Ruby # 仮想マシンにRuby環境をインストール(Gemのインストールやbundlerの準備を行う)
         uses: ruby/setup-ruby@v1 # Ruby公式が提供するRubyセットアップアクション
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Place test key
         run: echo "$RAILS_TEST_KEY" > config/credentials/test.key
@@ -120,7 +120,7 @@ jobs:
         run: bundle exec rspec
 
       - name: Keep screenshots from failed system tests
-        uses: actions/upload-artifact@v4 # ファイルをGitHub Actions上に保存
+        uses: actions/upload-artifact@v6 # ファイルをGitHub Actions上に保存
         if: failure()
         with:
           name: screenshots

--- a/.github/workflows/consume_medicine_task.yml
+++ b/.github/workflows/consume_medicine_task.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/notify_consultation_task.yml
+++ b/.github/workflows/notify_consultation_task.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/notify_medicine_task.yml
+++ b/.github/workflows/notify_medicine_task.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
### 概要

PR[#1]
checkout@v4をv6に変更しました。
dependabotでテストが通らなかったので新しくブランチを作成して対応しました。

### 作業内容
以下のファイルの`checkout@v4`を`checkout@v6`に変更
- .github/workflows/ci.yml
- .github/workflows/consume_medicine_task.yml
- .github/workflows/notify_consultation_task.yml
- .github/workflows/notify_medicine_task.yml