### PR TITLE
【Change】飲み忘れボタンの意味を分かりやすくする

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -7,21 +7,25 @@
   <div class="container mx-auto mb-10">
     <%= render "calendar", medicines_with_stock: @medicines_with_stock, consultation_schedules_by_date: @consultation_schedules_by_date %>
   </div>
-
-
   <div class="max-w-4xl mx-auto px-4 mb-20">
+    <div class="flex flex-col items-center">
 
-  <!-- メイン -->
-  <div class="actions text-center">
-    <%=link_to user_medicines_path, class: "btn btn-primary items-center justify-center gap-2 py-3 mb-10" do %>
-      <i class="fa-solid fa-plus"></i>
-      <span class="font-bold">薬を追加する</span>
-     <% end %>
-    <%= link_to forgot_index_user_medicines_path, class: "block text-center text-gray-500 hover:underline hover:text-gray-700" do %>
-      <span class="font-bold">飲み忘れに気づいたときはこちら</span>
-    <% end %>
+      <!-- 薬追加ボタン -->
+      <%= link_to user_medicines_path,
+          class: "btn btn-primary w-full max-w-md flex items-center justify-center gap-2 py-3 mb-8" do %>
+        <i class="fa-solid fa-plus"></i>
+        <span class="font-bold">薬を追加する</span>
+      <% end %>
+
+      <!-- 飲み忘れリンク -->
+      <%= link_to forgot_index_user_medicines_path,
+          class: "text-gray-500 hover:text-gray-700 hover:underline text-sm" do %>
+        <span class="font-bold">飲み忘れに気づいたときはこちら</span>
+      <% end %>
+
+    </div>
   </div>
-
+</div>
 <!-- モーダル枠 -->
 <turbo-frame id="stock_modal">
   <% if params[:date].present? %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -7,22 +7,20 @@
   <div class="container mx-auto mb-10">
     <%= render "calendar", medicines_with_stock: @medicines_with_stock, consultation_schedules_by_date: @consultation_schedules_by_date %>
   </div>
+
   <div class="max-w-4xl mx-auto px-4 mb-20">
     <div class="flex flex-col items-center">
-
       <!-- 薬追加ボタン -->
       <%= link_to user_medicines_path,
           class: "btn btn-primary w-full max-w-md flex items-center justify-center gap-2 py-3 mb-8" do %>
         <i class="fa-solid fa-plus"></i>
         <span class="font-bold">薬を追加する</span>
       <% end %>
-
       <!-- 飲み忘れリンク -->
       <%= link_to forgot_index_user_medicines_path,
           class: "text-gray-500 hover:text-gray-700 hover:underline text-sm" do %>
         <span class="font-bold">飲み忘れに気づいたときはこちら</span>
       <% end %>
-
     </div>
   </div>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -7,12 +7,21 @@
   <div class="container mx-auto mb-10">
     <%= render "calendar", medicines_with_stock: @medicines_with_stock, consultation_schedules_by_date: @consultation_schedules_by_date %>
   </div>
-  <!-- ボタン -->
-  <div class="flex max-w-4xl mx-auto gap-4 px-4 mb-20">
-    <%= link_to "薬の追加", user_medicines_path, class: "btn btn-primary flex-1" %>
-    <%= link_to "飲み忘れ", forgot_index_user_medicines_path, class: "btn btn-secondary flex-1" %>
+
+
+  <div class="max-w-4xl mx-auto px-4 mb-20">
+
+  <!-- メイン -->
+  <div class="actions text-center">
+    <%=link_to user_medicines_path, class: "btn btn-primary items-center justify-center gap-2 py-3 mb-10" do %>
+      <i class="fa-solid fa-plus"></i>
+      <span class="font-bold">薬を追加する</span>
+     <% end %>
+    <%= link_to forgot_index_user_medicines_path, class: "block text-center text-gray-500 hover:underline hover:text-gray-700" do %>
+      <span class="font-bold">飲み忘れに気づいたときはこちら</span>
+    <% end %>
   </div>
-</div>
+
 <!-- モーダル枠 -->
 <turbo-frame id="stock_modal">
   <% if params[:date].present? %>

--- a/app/views/user_medicines/_increment_stock_modal.html.erb
+++ b/app/views/user_medicines/_increment_stock_modal.html.erb
@@ -1,22 +1,34 @@
 <input type="checkbox" id="confirm-modal-<%= user_medicine.id %>" class="modal-toggle" />
 <div class="modal">
   <div class="modal-box">
-    <h3 class="font-bold text-lg">飲み忘れの確認</h3>
-    <p class="py-4">
-      <%= user_medicine.medicine.name %> は現在残り <%= user_medicine.current_stock %> 錠です。<br>
-      1回分増やしますか?
+  <h3 class="font-bold text-lg flex items-center gap-2">
+    在庫を1回分戻す
+  </h3>
+
+  <p class="py-4">
+    <%= user_medicine.medicine.name %> は現在残り <%= user_medicine.current_stock %> 錠です。<br>
+    1回分戻しますか?
+  </p>
+
+  <!-- 飲み忘れの説明 -->
+  <div class="absolute left-0 mt-2 w-72 bg-blue-50 border border-blue-200 rounded-lg p-3 shadow-lg">
+    <p class="text-blue-700 text-xs">
+        1回分の服薬量が戻り、手元の在庫数とアプリの在庫数を合わせることができます。
     </p>
-    <div class="modal-action">
-      <label for="confirm-modal-<%= user_medicine.id %>" class="btn">
-        キャンセル
-      </label>
-      <%= button_to "OK",
-                    increment_stock_user_medicine_path(user_medicine),
-                    method: :patch,
-                    form: { class: "inline" },
-                    class: "btn btn-primary" %>
-    </div>
   </div>
+
+  <div class="modal-action">
+    <label for="confirm-modal-<%= user_medicine.id %>" class="btn">
+      キャンセル
+    </label>
+
+    <%= button_to "OK",
+                  increment_stock_user_medicine_path(user_medicine),
+                  method: :patch,
+                  form: { class: "inline" },
+                  class: "btn btn-primary" %>
+  </div>
+</div>
   <form method="dialog" class="modal-backdrop">
     <button type="button">close</button>
   </form>

--- a/app/views/user_medicines/forgot_index.html.erb
+++ b/app/views/user_medicines/forgot_index.html.erb
@@ -16,7 +16,7 @@
   <div class="bg-white mx-auto rounded-lg shadow mb-6">
     <% if @medicines_with_stock.any? %>
       <% @medicines_with_stock.each do |user_medicine| %>
-        <div class="flex items-center justify-between p-4 border-b hover:bg-gray-50 mb-4" >
+        <div class="flex items-center justify-between p-4 border-b mb-4" >
           <div class="flex-1">
             <div class="flex items-center gap-2">
               <h3 class="font-semibold text-lg">

--- a/app/views/user_medicines/forgot_index.html.erb
+++ b/app/views/user_medicines/forgot_index.html.erb
@@ -1,8 +1,18 @@
 <div class="medicines-section max-w-2xl mx-auto mb-8">
   <h1 class="text-3xl mb-4 flex items-center justify-center gap-2" style="font-family: 'M PLUS Rounded 1c', sans-serif; font-weight: 500;">
     <%= render "shared/icon_medicine" %>
-    <span>飲み忘れ登録</span>
+    <span>飲み忘れ修正</span>
   </h1>
+  <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 max-w-2xl mx-auto mb-2">
+        <p class="text-blue-800 text-sm mb-2">
+          <i class="fa-solid fa-circle-info mr-2"></i>
+          <strong>飲み忘れた薬の飲み忘れボタンを押してください</strong>
+        </p>
+        <p class="text-blue-700 text-sm">
+           実際には飲んでいなかった薬を選択すると、1回分の服薬量が復元され、手元の在庫数ととアプリの在庫数を合わせることができます。
+        </p>
+      </div>
+
   <div class="bg-white mx-auto rounded-lg shadow mb-6">
     <% if @medicines_with_stock.any? %>
       <% @medicines_with_stock.each do |user_medicine| %>

--- a/app/views/user_medicines/forgot_index.html.erb
+++ b/app/views/user_medicines/forgot_index.html.erb
@@ -1,18 +1,18 @@
 <div class="medicines-section max-w-2xl mx-auto mb-8">
+  <!-- タイトルと説明文 -->
   <h1 class="text-3xl mb-4 flex items-center justify-center gap-2" style="font-family: 'M PLUS Rounded 1c', sans-serif; font-weight: 500;">
     <%= render "shared/icon_medicine" %>
-    <span>飲み忘れ修正</span>
+    <span>飲み忘れた薬の修正</span>
   </h1>
   <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 max-w-2xl mx-auto mb-2">
-        <p class="text-blue-800 text-sm mb-2">
-          <i class="fa-solid fa-circle-info mr-2"></i>
-          <strong>飲み忘れた薬の飲み忘れボタンを押してください</strong>
-        </p>
-        <p class="text-blue-700 text-sm">
-           実際には飲んでいなかった薬を選択すると、1回分の服薬量が復元され、手元の在庫数ととアプリの在庫数を合わせることができます。
-        </p>
-      </div>
-
+    <p class="text-blue-800 text-sm mb-2">
+      <i class="fa-solid fa-circle-info mr-2"></i>
+      <strong>飲み忘れていた薬の「飲み忘れ」ボタンを押してください</strong>
+    </p>
+    <p class="text-blue-700 text-sm">
+       実際には飲んでいなかった薬を選択すると、1回分の服薬量が戻り、手元の在庫数とアプリの在庫数を合わせることができます。
+    </p>
+  </div>
   <div class="bg-white mx-auto rounded-lg shadow mb-6">
     <% if @medicines_with_stock.any? %>
       <% @medicines_with_stock.each do |user_medicine| %>

--- a/app/views/user_medicines/show.html.erb
+++ b/app/views/user_medicines/show.html.erb
@@ -65,7 +65,7 @@
       <% if @user_medicine.has_stock? %>
         <div class="flex-1">
           <label for="confirm-modal-<%= @user_medicine.id %>" class="text-gray-500 hover:text-gray-700 hover:underline text-sm" do %>
-            飲み忘れに気づいたとき
+            飲み忘れに気づいたときはこちら
           </label>
         </div>
       <% end %>

--- a/app/views/user_medicines/show.html.erb
+++ b/app/views/user_medicines/show.html.erb
@@ -54,21 +54,21 @@
       </div>
     </div>
 
-    <div class="space-y-4">
-      <div class="flex gap-10">
-        <%= button_to "在庫を追加",
-                      add_stock_user_medicine_path(@user_medicine),
-                      method: :get,
-                      form: { class: "flex-1" },
-                      class: "btn btn-primary w-full" %>
-        <% if @user_medicine.has_stock? %>
-          <div class="flex-1">
-            <label for="confirm-modal-<%= @user_medicine.id %>" class="btn btn-secondary w-full cursor-pointer">
-              飲み忘れ
-            </label>
-          </div>
-        <% end %>
-      </div>
+    <div class="flex flex-col items-center mt-8">
+      <!-- 薬追加ボタン -->
+      <%= link_to add_stock_user_medicine_path(@user_medicine),
+          class: "btn btn-primary w-full max-w-md flex items-center justify-center gap-2 py-3 mb-8" do %>
+        <i class="fa-solid fa-plus"></i>
+        <span class="font-bold">在庫を追加する</span>
+      <% end %>
+      <!-- 飲み忘れリンク -->
+      <% if @user_medicine.has_stock? %>
+        <div class="flex-1">
+          <label for="confirm-modal-<%= @user_medicine.id %>" class="text-gray-500 hover:text-gray-700 hover:underline text-sm" do %>
+            飲み忘れに気づいたとき
+          </label>
+        </div>
+      <% end %>
     </div>
   </div>
 
@@ -76,6 +76,6 @@
   <div class="actions text-center">
     <%= link_to "薬一覧へ", user_medicines_path, class: "btn btn-neutral" %>
   </div>
-</div>
+
 <!-- モーダルの中身 -->
 <%= render "increment_stock_modal", user_medicine: @user_medicine %>

--- a/spec/system/user_medicines_spec.rb
+++ b/spec/system/user_medicines_spec.rb
@@ -97,19 +97,20 @@ RSpec.describe "UserMedicines", type: :system do
     describe "薬の飲み忘れ調整機能" do
       before do
         visit user_medicine_path(user_medicine)
+        page.driver.browser.manage.window.resize_to(1200, 1000)
       end
       context "飲み忘れボタンの表示" do
         context "在庫がある場合" do
           let(:user_medicine) { create(:user_medicine, user: user, medicine: medicine, current_stock: 10) }
-          it "飲み忘れボタンが表示される" do
-            expect(page).to have_css("label.btn.btn-secondary", text: "飲み忘れ"), "在庫がある場合、飲み忘れボタンが表示されていません"
+          it "「飲み忘れに気づいたときはこちら」が表示される" do
+            expect(page).to have_content("飲み忘れに気づいたときはこちら")
           end
         end
 
         context "在庫がない場合" do
           let(:user_medicine) { create(:user_medicine, user: user, medicine: medicine, current_stock: 0) }
           it "飲み忘れボタンが表示されない" do
-            expect(page).not_to have_button("飲み忘れ"), "在庫がない場合、飲み忘れボタンが表示されています"
+            expect(page).not_to have_content("飲み忘れに気づいたときはこちら"), "在庫がない場合、飲み忘れに気づいたときはこちらが表示されています"
           end
         end
       end
@@ -121,7 +122,8 @@ RSpec.describe "UserMedicines", type: :system do
         end
 
         it "確認ダイアログが表示され、はいを押すと在庫量が1回の服薬量分増える" do
-          find("label.btn.btn-secondary", text: "飲み忘れ").click
+          label = find("label[for='confirm-modal-#{user_medicine.id}']", text: '飲み忘れに気づいたとき')
+          label.click
           click_button "OK"
 
           expect(page).to have_content("在庫を1回分増やしました"), "フラッシュメッセージが表示されていません"
@@ -131,7 +133,8 @@ RSpec.describe "UserMedicines", type: :system do
         end
 
         it "確認ダイアログでいいえを押すと在庫量が変わらない" do
-          find("label.btn.btn-secondary", text: "飲み忘れ").click
+          label = find("label[for='confirm-modal-#{user_medicine.id}']", text: '飲み忘れに気づいたとき')
+          label.click
           find("label.btn", text: "キャンセル").click
 
           expect(page).to have_content("現在の在庫")


### PR DESCRIPTION
### 概要

issue [#252]
ホーム画面の「飲み忘れ」ボタンでは何ができるのか分かりにくかたので「飲み忘れに気づいた時はこちら」に変更し、遷移先の画面にも説明を加えました。「飲み忘れ」を押した際に出る確認モーダルにも説明を加えました。

### 作業内容
- ホーム画面
`app/views/home/index.html.erb`
「飲み忘れ」のボタンを「飲み忘れに気づいた時はこちら」のリンクに変更

**変更前**
<img width="813" height="373" alt="変更前ホーム画面" src="https://github.com/user-attachments/assets/b74c8143-d634-4bb5-9b31-94474dd2ea03" />

**変更後**
<img width="785" height="384" alt="変更後ホーム画面" src="https://github.com/user-attachments/assets/1ac9040b-ad96-4f81-bccd-d94c32fa2799" />

- 薬詳細画面
`app/views/user_medicines/show.html.erb`
「飲み忘れ」ボタンから「飲み忘れに気づいた時はこちら」のリンクに変更

- ホームの「飲み忘れに気づいた時はこちら」の遷移先
`app/views/user_medicines/forgot_index.html.erb`
タイトルを「飲み忘れ登録」から「飲み忘れた薬の修正」に変更し、一覧表示の「飲み忘れ」ボタンを押してできることの説明を記述

**変更後**
<img width="745" height="339" alt="変更後飲み忘れ修正" src="https://github.com/user-attachments/assets/30353285-d515-4bb2-a705-b599b39de4d8" />

- 飲み忘れボタンを押したときの確認モーダル
`app/views/user_medicines/_increment_stock_modal.html.erb`
タイトルを「飲み忘れの確認」から「在庫を1回分戻す」に変更し、「1回分の服薬量が戻り、手元の在庫数とアプリの在庫数を合わせることができます。」と説明を追加

**変更前**
<img width="558" height="269" alt="変更前モーダル" src="https://github.com/user-attachments/assets/301648e8-deec-4673-ad7e-b7837d5b0757" />

**変更後**
<img width="587" height="386" alt="修正後モーダル" src="https://github.com/user-attachments/assets/79e8ae29-a02b-444c-a01f-566d394f594a" />
