### PR TITLE
【Bugfix】SNS認証でログインしたユーザーにアカウント設定画面が表示されないようにする

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,11 @@ class User < ApplicationRecord
     end
   end
 
+  # 通常のログインの場合
+  def email_authentication?
+    provider.nil?
+  end
+
   private
 
   def create_default_notifications

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -2,49 +2,51 @@
   <h1 class="text-3xl mb-4 mt-6 flex items-center justify-center gap-2" style="font-family: 'M PLUS Rounded 1c', sans-serif; font-weight: 500;">
     <span>アカウント設定</span>
   </h1>
-  <div class="bg-base-200 rounded-lg shadow p-6">
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-      <%= render "shared/error_messages", object: f.object %>
+  <% if @user.email_authentication? %>
+    <div class="bg-base-200 rounded-lg shadow p-6">
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+        <%= render "shared/error_messages", object: f.object %>
 
-      <!-- メールアドレス -->
-      <div class="mb-4">
-        <%= f.label :email, class: "label-text mb-1 block" %>
-        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: form_field_class(resource, :email) %>
-      </div>
-
-      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-        <div class="mb-4">Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-      <% end %>
-
-      <!-- パスワード -->
-      <div class="mb-4">
-        <div class="mb-1">
-          <%= f.label :password, class: "label-text" %>
-          <% if @minimum_password_length %>
-            <span class="text-xs ml-1">(<%= @minimum_password_length %> 文字以上)</span>
-          <% end %>
+        <!-- メールアドレス -->
+        <div class="mb-4">
+          <%= f.label :email, class: "label-text mb-1 block" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: form_field_class(resource, :email) %>
         </div>
-        <%= f.password_field :password, autocomplete: "new-password", class: form_field_class(resource, :password) %>
-      </div>
 
-      <!-- パスワード確認 -->
-      <div class="mb-4">
-        <%= f.label :password_confirmation, class: "label-text mb-1 block" %>
-        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: form_field_class(resource, :password_confirmation) %>
-      </div>
+        <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+          <div class="mb-4">Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+        <% end %>
 
-      <!-- 現在のパスワード -->
-      <div class="mb-4">
-        <p class="text-sm mb-2">本人確認のため、現在のパスワードを入力してください。</p>
-        <%= f.label :current_password, class: "label-text mb-1 block" %>
-        <%= f.password_field :current_password, autocomplete: "current-password", class: form_field_class(resource, :current_password) %>
-      </div>
+        <!-- パスワード -->
+        <div class="mb-4">
+          <div class="mb-1">
+            <%= f.label :password, class: "label-text" %>
+            <% if @minimum_password_length %>
+              <span class="text-xs ml-1">(<%= @minimum_password_length %> 文字以上)</span>
+            <% end %>
+          </div>
+          <%= f.password_field :password, autocomplete: "new-password", class: form_field_class(resource, :password) %>
+        </div>
 
-      <div class="actions text-center mt-5">
-        <%= f.submit "変更する", class: "btn btn-secondary" %>
-      </div>
-    <% end %>
-  </div>
+        <!-- パスワード確認 -->
+        <div class="mb-4">
+          <%= f.label :password_confirmation, class: "label-text mb-1 block" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: form_field_class(resource, :password_confirmation) %>
+        </div>
+
+        <!-- 現在のパスワード -->
+        <div class="mb-4">
+          <p class="text-sm mb-2">本人確認のため、現在のパスワードを入力してください。</p>
+          <%= f.label :current_password, class: "label-text mb-1 block" %>
+          <%= f.password_field :current_password, autocomplete: "current-password", class: form_field_class(resource, :current_password) %>
+        </div>
+
+        <div class="actions text-center mt-5">
+          <%= f.submit "変更する", class: "btn btn-secondary" %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
 
   <div class="text-center">
     <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete, confirm: t(".logout_confirmation"), turbo_confirm: t(".logout_confirmation") }, class: "btn bg-white text-[#E56A54] border border-[#E56A54] hover:bg-[#FFE4DF] w-full max-w-xs mt-10" %>

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -10,6 +10,7 @@ if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
   ./bin/rails db:prepare
 fi
 
+bundle install
 # cronデーモンを起動
 service cron start
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -10,8 +10,14 @@ FactoryBot.define do
 
     # LINEでログインしたユーザー
     trait :line_login do
+      provider { "line" }
       sequence(:line_user_id) { |n| "line_uid_#{n}" }
       email { "#{line_user_id}@line.example.com" }
+    end
+
+    trait :google_login do
+      provider { "google_oauth2" }
+      sequence(:email) { |n| "user_#{n}@gmail.con" }
     end
   end
 end

--- a/spec/system/users/edit_registrations_spec.rb
+++ b/spec/system/users/edit_registrations_spec.rb
@@ -12,6 +12,24 @@ RSpec.describe "UserEditRegistrations", type: :system do
       visit edit_user_registration_path
     end
 
+    context "通常ログインユーザーの場合" do
+      it "メールアドレス・パスワード編集セクションが表示されること" do
+        expect(page).to have_selector(".bg-base-200.rounded-lg.shadow.p-6")
+      end
+    end
+
+    context "Googleログインユーザーの場合" do
+      it "メールアドレス・パスワード編集セクションが表示されないこと" do
+        expect(page).not_to have_selector(".bg-base-200.rounded-lg.shadow.p-6")
+      end
+    end
+
+    context "LINEログインユーザーの場合" do
+      it "メールアドレス・パスワード編集セクションが表示されないこと" do
+        expect(page).not_to have_selector(".bg-base-200.rounded-lg.shadow.p-6")
+      end
+    end
+
     context "正常系" do
       it "メールアドレスが変更できる" do
         fill_in "メールアドレス", with: "new@example.com"

--- a/spec/system/users/edit_registrations_spec.rb
+++ b/spec/system/users/edit_registrations_spec.rb
@@ -2,33 +2,49 @@ require "rails_helper"
 
 RSpec.describe "UserEditRegistrations", type: :system do
   let(:user) { create(:user, email: "original@example.com", password: "password") }
+  let(:google_user) { create(:user, :google_login) }
+  let(:line_user) { create(:user, :line_login) }
 
-  before do
-    login_as(user)
-  end
-
-  describe "ユーザー情報編集" do
-    before do
-      visit edit_user_registration_path
-    end
-
+  describe "ユーザー編集画面の出し分け" do
     context "通常ログインユーザーの場合" do
+      before do
+        login_as(user)
+        visit edit_user_registration_path
+      end
+
       it "メールアドレス・パスワード編集セクションが表示されること" do
         expect(page).to have_selector(".bg-base-200.rounded-lg.shadow.p-6")
       end
     end
 
     context "Googleログインユーザーの場合" do
+      before do
+        login_as(google_user)
+         visit edit_user_registration_path
+      end
+
       it "メールアドレス・パスワード編集セクションが表示されないこと" do
         expect(page).not_to have_selector(".bg-base-200.rounded-lg.shadow.p-6")
       end
     end
 
     context "LINEログインユーザーの場合" do
+      before do
+        login_as(line_user)
+        visit edit_user_registration_path
+      end
+
       it "メールアドレス・パスワード編集セクションが表示されないこと" do
         expect(page).not_to have_selector(".bg-base-200.rounded-lg.shadow.p-6")
       end
     end
+  end
+
+  describe "ユーザー情報編集" do
+    before do
+      login_as(user)
+      visit edit_user_registration_path
+  end
 
     context "正常系" do
       it "メールアドレスが変更できる" do
@@ -81,6 +97,7 @@ RSpec.describe "UserEditRegistrations", type: :system do
 
   describe "アカウント削除" do
     before do
+      login_as(user)
       visit edit_user_registration_path
     end
 

--- a/spec/system/users/edit_registrations_spec.rb
+++ b/spec/system/users/edit_registrations_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "UserEditRegistrations", type: :system do
     context "Googleログインユーザーの場合" do
       before do
         login_as(google_user)
-         visit edit_user_registration_path
+        visit edit_user_registration_path
       end
 
       it "メールアドレス・パスワード編集セクションが表示されないこと" do
@@ -42,8 +42,8 @@ RSpec.describe "UserEditRegistrations", type: :system do
 
   describe "ユーザー情報編集" do
     before do
-      login_as(user)
-      visit edit_user_registration_path
+    login_as(user)
+    visit edit_user_registration_path
   end
 
     context "正常系" do


### PR DESCRIPTION
### 概要

issue [#260]
LINEログインとGoogleログインでログインしたユーザーにメールアドレスとパスワード変更の画面が表示されないようにしました。

### 作業内容
**アカウント設定の出し分け**
1. app/models/user.rb
ユーザーが通常ログインでログインしたかどうかを、provider
がnilかどうかで判定する`email_authentication?`メソッドを定義
2. app/views/devise/registrations/edit.html.erb
`if @user.email_authentication?`で条件分岐し、通常ログインのユーザーのみアカウント設定画面を表示

**テスト**
1. spec/factories/users.rb
GoogleログインでログインするユーザーをFactoryBotで作成
2. spec/system/users/edit_registrations_spec.rb
通常ログインユーザーはアカウント設定画面が表示され、LINEログインとGoogleログインユーザーは表示されないテストを記述