### PR TITLE
【fix】ブラウザ検索結果のタイトルを「Okan」から「OKAN」に変更

### DIFF
--- a/app/views/pwa/manifest.json
+++ b/app/views/pwa/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Okan - おくすりかんり",
+  "name": "OKAN - おくすりかんり",
   "short_name": "OKAN",
   "description": "お薬管理アプリ",
   "start_url": "/",


### PR DESCRIPTION
### 概要

[#274]
ブラウザ検索結果のタイトルを「Okan」から「OKAN」に変更しました。

### 作業内容
app/views/pwa/manifest.json
nameを「Okan」から「OKAN」に編集

### 実施理由
アプリ名を正確に表示するために変更しました。
