### PR TITLE
【fix】ブラウザタブのデフォルトタイトルを「Okan」から「OKAN」に修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
         });
       }
     </script>
-    <title><%= content_for(:title) || "Okan" %></title>
+    <title><%= content_for(:title) || "OKAN" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>


### PR DESCRIPTION
## 概要
ブラウザのタブやブックマークに表示されるデフォルトタイトルが「Okan」になっていたため「OKAN」に修正した。

## 原因と背景
- #275 では `views/pwa/manifest.json` の `name` を修正したが、ブラウザタブのタイトルは `app/views/layouts/application.html.erb` の `<title>` タグで制御されており、そちらのデフォルト値が「Okan」のままだったため未解決だった。

## 修正内容
`app/views/layouts/application.html.erb`

```erb
- <title><%= content_for(:title) || "Okan" %></title>
+ <title><%= content_for(:title) || "OKAN" %></title>
```

## 関連
- Closes #276
- Related to #275