### PR TITLE
【fix】重複した<title>タグを削除しブラウザ検索タイトルを正しく表示する

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,6 @@
         });
       }
     </script>
-    <title><%= content_for(:title) || "OKAN" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>


### PR DESCRIPTION
## 概要
`application.html.erb` に `<title>` タグが2つレンダリングされていた問題を修正する。

## 問題の詳細
- Line 26 の `<title><%= content_for(:title) || "OKAN" %></title>` と、`display_meta_tags` が出力する `<title>お薬管理アプリOKAN</title>` の2つが存在していた
- 重複した `<title>` タグは無効なHTMLであり、Googleが意図しないタイトルを使用する原因となっていた
- `content_for(:title)` はどのビューでも使用されておらず、死んだコードだった

## 修正内容
- `<title><%= content_for(:title) || "OKAN" %></title>` を削除
- `display_meta_tags` の `title: "お薬管理アプリOKAN"` のみが `<title>` として使用されるようにする

## 関連Issue・PR
Closes #278
Related to #277
Related to #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)