### PR TITLE
fix: 今日が土日の場合もカレンダーのピンク背景を優先する

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -108,4 +108,10 @@
   .wday-6 {
     background-color: #F3F4F6;
   }
+
+  /* 今日が土日の場合はピンクを優先 */
+  .today.wday-0,
+  .today.wday-6 {
+    background-color: #FDEDE9;
+  }
 }


### PR DESCRIPTION
## Summary

- `.today.wday-0` と `.today.wday-6` の組み合わせセレクタを追加し、今日が土日の場合もピンク背景が適用されるよう修正

## 原因

`application.css` で `.today`（詳細度: 1クラス）が `.wday-0`/`.wday-6`（同: 1クラス）より前に定義されているため、CSS カスケードによりグレーが上書きされていた。

## 修正内容

```css
/* 今日が土日の場合はピンクを優先 */
.today.wday-0,
.today.wday-6 {
  background-color: #FDEDE9;
}
```

詳細度を2クラス分に上げることでピンクを優先させる。

## 関連 Issue

closes #280

## Test plan

- [x] 今日の日付が平日のときピンク背景が表示される
- [ ] 今日の日付が土曜日のときピンク背景が表示される（グレーに上書きされない）
- [ ] 今日の日付が日曜日のときピンク背景が表示される（グレーに上書きされない）
- [x] 今日以外の土日はグレー背景のまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)